### PR TITLE
Getting CICD tests to run

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -73,7 +73,7 @@ jobs:
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{hashFiles('**/poetry.lock') }}
       - name: Install package
         run: |
-          poetry install --no-interaction --no-root
+          poetry install --no-interaction
 
       - name: Run Unit Tests
         run: | 


### PR DESCRIPTION
Removing --no-root so pytest gets installed, and the tests actually run.