### PR TITLE
k3s deployment for inference container

### DIFF
--- a/deploy/k3s/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment.yaml
@@ -48,29 +48,27 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: triton-inference
+  name: inference-server
   labels:
-    app: triton-inference
+    app: inference-server
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: triton-inference
+      app: inference-server
   template:
     metadata:
       labels:
-        app: triton-inference
+        app: inference-server
     spec:
       containers:
-      - name: triton-inference
+      - name: inference-server
         image: 723181461334.dkr.ecr.us-west-2.amazonaws.com/gl-tritonserver:main-749c0cca3-dirty-0325a8beabe0d7b
         imagePullPolicy: IfNotPresent
-        args:
         # Tritonserver will look for models in /mnt/models and initialize them on startup
-        # TODO: We only want to shut down an old instance when this tritonsever
-        # gives the "READY" signal for all models
-        - tritonserver
-        - --model-repository=/mnt/models
+        # TODO: We only want to shut down an old instance when this tritonsever gives the "READY" signal for all models
+        command:
+          ["tritonserver", "--model-repository=/mnt/models"]
         volumeMounts:
         - name: model-repo
           mountPath: /mnt/models

--- a/deploy/make-aws-secret.sh
+++ b/deploy/make-aws-secret.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -ex
+
+K="k3s kubectl"
 
 # Enable ECR login - make sure you have the aws client configured properly, or an IAM role
 # attached to your instance
@@ -11,10 +14,10 @@ aws ecr get-login-password --region us-west-2 | docker login \
 
 # Create an AWS secret for the edge-endpoint to properly pull images from ECR
 # Note: needs testing
-k3s kubectl delete --ignore-not-found secret registry-credentials
+$K delete --ignore-not-found secret registry-credentials
 
 PASSWORD=$(aws ecr get-login-password --region us-west-2)
-k3s kubectl create secret docker-registry registry-credentials \
+$K create secret docker-registry registry-credentials \
     --docker-server=723181461334.dkr.ecr.us-west-2.amazonaws.com \
     --docker-username=AWS \
     --docker-password=$PASSWORD

--- a/deploy/make-gl-api-token-secret.sh
+++ b/deploy/make-gl-api-token-secret.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+set -ex
+
+K="k3s kubectl"
+
 # Create a kubernetes secret for the groundlight api token
 # Make sure that you have the groundlight api token set in your environment
 
-k3s kubectl create secret generic groundlight-secrets \
+$K create secret generic groundlight-secrets \
     --from-literal=api-token=${GROUNDLIGHT_API_TOKEN}


### PR DESCRIPTION
Setup a deployment that runs a triton inference server built with Groundlight's dependencies!

If you have zuuul checked out at `/home/ubuntu/ptdev/zuuul` then this deployment will use `hostPath` to mount the demo model repository (`zuuul/predictors/serving/model_repository`).

Inspection of the inference server's logs confirms that things are working as intended:
```
I0828 18:29:05.638853 1 server.cc:674]
+------------+---------+--------+
| Model      | Version | Status |
+------------+---------+--------+
| demo_model | 1       | READY  |
+------------+---------+--------+
```