### PR TITLE
[small] validate request body in post image query

### DIFF
--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -37,8 +37,8 @@ async def validate_request_body(request: Request) -> Image.Image:
 
         image.load()
         return image
-    except Exception as e:
-        logger.error(f"Failed to load image: {e}")
+    except Exception:
+        logger.error("Failed to load image", exc_info=True)
         raise HTTPException(status_code=400, detail="Invalid input image")
 
 


### PR DESCRIPTION
Previously we had `ImageFile.LOAD_TRUNCATED_IMAGES = True`, which allowed `pillow` to load truncated images, which is not what we want. The SDK also has tests that specifically expect this to raise an error. This PR adds validation so that we raise a 400 error whenever we have invalid image bytes in the request body. 