### PR TITLE
Remove `--target production-image` requirement while building docker image 

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install docker-ce
       - name: Build Docker Image
-        run: docker build --target production-image --tag groundlight-edge .
+        run: docker build --tag groundlight-edge .
         
       - name: Start Docker Container
         id: start_container
@@ -102,7 +102,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install docker-ce
       - name: Build Docker Image 
-        run: docker build --target production-image --tag groundlight-edge .
+        run: docker build --tag groundlight-edge .
 
       - name: Start Docker Container 
         id: start_container

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,24 +78,3 @@ CMD nginx && poetry run uvicorn --workers 1 --host 0.0.0.0 --port ${APP_PORT} --
 # https://docs.docker.com/engine/reference/builder/#expose
 EXPOSE ${APP_PORT}
 
-#########################
-# Development Build Stage
-#########################
-FROM production-dependencies-build-stage as dev-dependencies-build-stage
-
-RUN poetry install --no-interaction --no-root
-
-###################
-# Development Stage
-###################
-FROM production-dependencies-build-stage as development-image
-
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    UVICORN_RELOAD=1 \
-    UVICORN_LOG_LEVEL=debug
-
-WORKDIR ${APP_ROOT}
-
-# Copy all files for development
-COPY . ${APP_ROOT}/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For more information on how to run Groundlight on the edge, checkout our [docume
 The recommended way to run the Edge Endpoint is inside a docker container as follows:
 
 ```bash
-docker build --target production-image --tag edge-endpoint .
+docker build --tag edge-endpoint .
 export EDGE_CONFIG=$(cat configs/edge-config.yaml)
 # Run the endpoint as a container in the background
 docker run -d --name groundlight-edge -e EDGE_CONFIG --rm -p 6717:6717 edge-endpoint

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -65,7 +65,7 @@ Follow the following steps:
 
 ```shell
 # Creating our edge-endpoint docker image. Make sure you are in the root directory
-> docker build --target production-image --tag edge-endpoint .
+> docker build --tag edge-endpoint .
 
 # Check that the image was created successfully
 > docker images 

--- a/deploy/bin/build-push-edge-endpoint-image.sh
+++ b/deploy/bin/build-push-edge-endpoint-image.sh
@@ -30,7 +30,7 @@ fi
 docker buildx inspect tempgroundlightedgebuilder --bootstrap
 
 # Build image for amd64 and arm64
-docker buildx build --platform linux/amd64,linux/arm64 --target production-image --tag edge-endpoint ../..
+docker buildx build --platform linux/amd64,linux/arm64 --tag edge-endpoint ../..
 
 # Tag image
 docker tag edge-endpoint:latest 723181461334.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:${TAG}

--- a/test/setup_test_env.sh
+++ b/test/setup_test_env.sh
@@ -10,7 +10,7 @@
 # an API token from this account if you don't have one already. 
 
 # Use the script as follows:
-# > docker build --target production-image --tag edge-endpoint .
+# > docker build --tag edge-endpoint .
 # > source test/setup_test_env.sh
 # > docker run --name groundlight-edge \
 #      -e LOG_LEVEL=DEBUG \


### PR DESCRIPTION
This PR removes the `development-image` from Dockerfile, and with that change allows us to build docker images without having to specify `--target production-image`. 