### PR TITLE
Github action that sets up k3s

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -31,12 +31,13 @@ jobs:
       - name: Wait for edge-endpoint pod to be ready
         run: |
           set -ex
+          kubectl describe deployment edge-endpoint
           sleep 10
-          kubectl describe pod edge-endpoint
+          kubectl describe pod edge-endpoint || echo "not ready yet"
           sleep 10
-          kubectl describe pod edge-endpoint
+          kubectl describe pod edge-endpoint || echo "not ready yet"
           sleep 10
-          kubectl describe pod edge-endpoint
+          kubectl describe pod edge-endpoint  # at least the pod should be ready by now
           
           # Really we should wait for it to successfully deploy:
           #kubectl rollout status deployment edge-endpoint --timeout=5m


### PR DESCRIPTION
This is an extremely simple test that uses k3s, and barely verifies anything.  It just installs k3s, applies our deployment, and checks that a pod is created.  The pod doesn't currently work, so the deployment never finishes rolling out.  But it is a possibly-useful test, and definitely a POC of how we can build k3s tests in github.