### PR TITLE
Autolaunch Cluster when starting Edge-Endpoint

### DIFF
--- a/deploy/balena-k3s/README.md
+++ b/deploy/balena-k3s/README.md
@@ -19,7 +19,10 @@ AWS_ACCESS_KEY_ID - so we can pull the edge-endpoint and gl-tritonserver images 
 AWS_SECRET_ACCESS_KEY - needed along with AWS_ACCESS_KEY_ID
 ```
 
-Now, ssh into `bastion` and run the following:
+Optionally you can also configure `EDGE_INFERENCE_FLAVOR` to use GPU instead. It will default to CPU if not set.
+
+Dockerfile will automatically run the following command as `bastion` launches so no need to run this anymore.
+
 ```bash
 cd /app/edge-endpoint
 INFERENCE_FLAVOR="CPU" DEPLOYMENT_NAMESPACE="default" ./deploy/bin/cluster_setup.sh

--- a/deploy/balena-k3s/bastion/Dockerfile
+++ b/deploy/balena-k3s/bastion/Dockerfile
@@ -51,8 +51,9 @@ RUN arkade version && \
 RUN mkdir -p /app/edge-endpoint
 COPY . /app/edge-endpoint
 
-# Set environment variables for running cluster setup
-ENV INFERENCE_FLAVOR="CPU"
+# Set environment variables for running cluster setup based on env var EDGE_INFERENCE_FLAVOR, defaults to CPU if not set
+ARG INFERENCE_FLAVOR_ARG="CPU"
+ENV INFERENCE_FLAVOR=${EDGE_INFERENCE_FLAVOR:-$INFERENCE_FLAVOR_ARG}
 ENV DEPLOYMENT_NAMESPACE="default"
 
 RUN chmod +x ./edge-endpoint/deploy/bin/cluster_setup.sh


### PR DESCRIPTION
Modified the Dockerfile to launch cluster when bastion launches. This will make the setup process easier, especially when integrating with `glhub`.