### PR TITLE
Fix auto-install of nvidia drivers

### DIFF
--- a/deploy/bin/install-k3s-g4.sh
+++ b/deploy/bin/install-k3s-g4.sh
@@ -2,7 +2,6 @@
 
 # Install k3s and configure GPU support
 # Tested on an AWS EC2 G4 instance using the following AMI:
-# Deep Learning AMI GPU PyTorch 2.0.1 (Ubuntu 20.04) 20230827
 # Deep Learning OSS Nvidia Driver AMI GPU PyTorch 2.3.0 (Ubuntu 20.04) 20240825
 
 # This guide was more helpful than others fwiw:


### PR DESCRIPTION
This worked out of the box on a fresh g4 instance (in fact, nothing needed to be done by `check_nvidia_drivers_and_container_runtime` at all). 

```
kubectl describe node
...
Capacity:
  cpu:                4
  ephemeral-storage:  203056560Ki
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             16070168Ki
  nvidia.com/gpu:     1
  pods:               110
...
```