### PR TITLE
Add Support for Edge to use Latest Build Images for Endpoint and Inference

### DIFF
--- a/deploy/balena-k3s/bastion/Dockerfile
+++ b/deploy/balena-k3s/bastion/Dockerfile
@@ -51,10 +51,6 @@ RUN arkade version && \
 RUN mkdir -p /app/edge-endpoint
 COPY . /app/edge-endpoint
 
-# Set environment variables for running cluster setup based on env var EDGE_INFERENCE_FLAVOR, defaults to CPU if not set
-ARG INFERENCE_FLAVOR_ARG="CPU"
-ENV INFERENCE_FLAVOR=${EDGE_INFERENCE_FLAVOR:-$INFERENCE_FLAVOR_ARG}
-ENV DEPLOYMENT_NAMESPACE="default"
 
 RUN chmod +x ./edge-endpoint/deploy/bin/cluster_setup.sh
 

--- a/deploy/bin/build-push-edge-endpoint-image.sh
+++ b/deploy/bin/build-push-edge-endpoint-image.sh
@@ -49,4 +49,5 @@ docker buildx inspect tempgroundlightedgebuilder --bootstrap
 docker buildx build \
   --platform linux/arm64,linux/amd64 \
   --tag ${ECR_URL}/${EDGE_ENDPOINT_IMAGE}:${TAG} \
+  --tag ${ECR_URL}/${EDGE_ENDPOINT_IMAGE}:latest \
   ../.. --push

--- a/deploy/bin/cluster_setup.sh
+++ b/deploy/bin/cluster_setup.sh
@@ -66,7 +66,7 @@ K=${KUBECTL_CMD:-"kubectl"}
 INFERENCE_FLAVOR=${INFERENCE_FLAVOR:-"GPU"}
 DB_RESET=$1
 DEPLOY_LOCAL_VERSION=${DEPLOY_LOCAL_VERSION:-1}
-DEPLOYMENT_NAMESPACE=${DEPLOYMENT_NAMESPACE:-$($K config view -o json | jq -r '.contexts[] | select(.name == "'$($K config current-context)'") | .context.namespace')}
+DEPLOYMENT_NAMESPACE=${DEPLOYMENT_NAMESPACE:-$($K config view -o json | jq -r '.contexts[] | select(.name == "'$($K config current-context)'") | .context.namespace // "default"')}
 
 
 # move to the root directory of the repo

--- a/deploy/k3s/edge_deployment/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment/edge_deployment.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: edge-endpoint-service-account
       initContainers:
       - name: database-prep
-        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint-test:main-eeca586c2-dirty-dab5c71f7885c26
+        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint-test:latest
         imagePullPolicy: IfNotPresent
         env:
         # Flag to indicate whether or not to reset all database tables. Resetting WILL delete
@@ -59,7 +59,7 @@ spec:
 
       containers:
       - name: edge-endpoint
-        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint-test:main-eeca586c2-dirty-dab5c71f7885c26
+        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint-test:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6717
@@ -83,7 +83,7 @@ spec:
           mountPath: /opt/groundlight/edge/sqlite
 
       - name: inference-model-updater
-        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint-test:main-eeca586c2-dirty-dab5c71f7885c26
+        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint-test:latest
         imagePullPolicy: IfNotPresent
         command: ["/bin/bash", "-c"]
         args: ["poetry run python -m app.model_updater.update_models"]

--- a/deploy/k3s/inference_deployment/inference_deployment_template.yaml
+++ b/deploy/k3s/inference_deployment/inference_deployment_template.yaml
@@ -40,7 +40,7 @@ spec:
           maxUnavailable: 0  # Aim for no downtime during rollout
       containers:
       - name: inference-server
-        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/gl-tritonserver-test:674426bc8-main
+        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/gl-tritonserver-test:latest
         imagePullPolicy: IfNotPresent
         # Tritonserver will look for models in /mnt/models and initialize them on startup.
         # When running multiple instances of Triton server on the same machine that use Python models,


### PR DESCRIPTION
This is the part 2 of the PRs that adds the `latest` tag to Docker Image so that `edge-endpoint` can always fetch the latest version.
Part 1 of the PR can be found here: https://github.com/positronix-ai/zuuul/pull/3969