### PR TITLE
Fix docker run command in README to work on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The recommended way to run the Edge Endpoint is inside a docker container as fol
 docker build --tag edge-endpoint .
 export EDGE_CONFIG=$(cat configs/edge-config.yaml)
 # Run the endpoint as a container in the background
-docker run -d --name groundlight-edge -e EDGE_CONFIG --rm -p 6717:6717 edge-endpoint
+docker run -d --name groundlight-edge -e EDGE_CONFIG="$EDGE_CONFIG" --rm -p 6717:6717 edge-endpoint
 ```
 
 Then you can follow the logs or stop it with these commands:


### PR DESCRIPTION
Previous command didn't work on Ubuntu 20 when setting up on beebop.