### PR TITLE
Fixed communication error due to incorrect endpoint

### DIFF
--- a/app/core/kubernetes_management.py
+++ b/app/core/kubernetes_management.py
@@ -78,7 +78,9 @@ class InferenceDeploymentManager:
         inference_deployment = self._inference_deployment_template
         inference_deployment = inference_deployment.replace("placeholder-inference-service-name", service_name)
         inference_deployment = inference_deployment.replace("placeholder-inference-deployment-name", deployment_name)
-        inference_deployment = inference_deployment.replace("placeholder-inference-instance-name", f"instance-{detector_id}")
+        inference_deployment = inference_deployment.replace(
+            "placeholder-inference-instance-name", f"instance-{detector_id}"
+        )
         inference_deployment = inference_deployment.replace("placeholder-model-name", detector_id)
         return inference_deployment.strip()
 

--- a/app/core/kubernetes_management.py
+++ b/app/core/kubernetes_management.py
@@ -78,6 +78,7 @@ class InferenceDeploymentManager:
         inference_deployment = self._inference_deployment_template
         inference_deployment = inference_deployment.replace("placeholder-inference-service-name", service_name)
         inference_deployment = inference_deployment.replace("placeholder-inference-deployment-name", deployment_name)
+        inference_deployment = inference_deployment.replace("placeholder-inference-instance-name", f"instance-{detector_id}")
         inference_deployment = inference_deployment.replace("placeholder-model-name", detector_id)
         return inference_deployment.strip()
 

--- a/deploy/k3s/inference_deployment/inference_deployment_template.yaml
+++ b/deploy/k3s/inference_deployment/inference_deployment_template.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   selector:
     app: inference-server
+    instance: placeholder-inference-instance-name
   ports:
     - protocol: TCP
       port: 8000
@@ -27,10 +28,12 @@ spec:
   selector:
     matchLabels:
       app: inference-server
+      instance: placeholder-inference-instance-name
   template:
     metadata:
       labels:
         app: inference-server
+        instance: placeholder-inference-instance-name
     spec:
       runtimeClassName: nvidia  # Required for GPU use in k3s
       strategy:


### PR DESCRIPTION
This PR fixes overlapping endpoints that is causing the inference pods to not communicating with the edge-endpoint pod.

Note since we are using tag `latest` for edge images, you will need to manually delete the image saved on the machine so that it can pull the latest version. Might need to look into that to make it more versatile (using hash to detect new version?).