### PR TITLE
Enabling EDGE_ONLY option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ print(f"The answer is {image_query.result}")
 
 See the [SDK's getting started guide](https://code.groundlight.ai/python-sdk/docs/getting-started) for more info.
 
+### Experimental: getting only edge model answers
+If you only want to receive answers from the edge model, you can set the `EDGE_ONLY` environment variable like so:
+```
+export EDGE_ONLY=ENABLED
+```
+Then, if you make requests to the edge endpoint using the `ask_async` method, you will only receive answers from the edge model (regardless of the confidence). Additionally, note that no image queries submitted this way will show up in the web app or be used to train the model. This option should therefore only be used if you don't need the model to improve, and only want fast answers from the edge model.
+
+This is an experimental feature and may be modified or removed in the future.
+
 ## Development and Internal Architecture
 
 This section describes the various components that comprise the Groundlight Edge Endpoint, and how they interoperate.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ If you only want to receive answers from the edge model, you can set the `EDGE_O
 ```
 Then, if you make requests to the edge endpoint, you will only receive answers from the edge model (regardless of the confidence). Additionally, note that no image queries submitted this way will show up in the web app or be used to train the model. This option should therefore only be used if you don't need the model to improve and only want fast answers from the edge model.
 
+If this flag is enabled and the edge inference model for a detector is not available, attempting to send image queries to that detector will return a 500 error response.
+
 This feature is currently not fully compatible with motion detection. If motion detection is enabled, some image queries may still be sent to the cloud API.
 
 This is an experimental feature and may be modified or removed in the future. `EDGE_ONLY` is disabled by default.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you only want to receive answers from the edge model, you can set the `EDGE_O
 - name: EDGE_ONLY
     value: "ENABLED"
 ```
-Then, if you make requests to the edge endpoint using the `ask_async` method, you will only receive answers from the edge model (regardless of the confidence). Additionally, note that no image queries submitted this way will show up in the web app or be used to train the model. This option should therefore only be used if you don't need the model to improve and only want fast answers from the edge model.
+Then, if you make requests to the edge endpoint, you will only receive answers from the edge model (regardless of the confidence). Additionally, note that no image queries submitted this way will show up in the web app or be used to train the model. This option should therefore only be used if you don't need the model to improve and only want fast answers from the edge model.
 
 This is an experimental feature and may be modified or removed in the future. `EDGE_ONLY` is disabled by default.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ If you only want to receive answers from the edge model, you can set the `EDGE_O
 ```
 Then, if you make requests to the edge endpoint, you will only receive answers from the edge model (regardless of the confidence). Additionally, note that no image queries submitted this way will show up in the web app or be used to train the model. This option should therefore only be used if you don't need the model to improve and only want fast answers from the edge model.
 
+This feature is currently not fully compatible with motion detection. If motion detection is enabled, some image queries may still be sent to the cloud API.
+
 This is an experimental feature and may be modified or removed in the future. `EDGE_ONLY` is disabled by default.
 
 ## Development and Internal Architecture

--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ print(f"The answer is {image_query.result}")
 See the [SDK's getting started guide](https://code.groundlight.ai/python-sdk/docs/getting-started) for more info.
 
 ### Experimental: getting only edge model answers
-If you only want to receive answers from the edge model, you can set the `EDGE_ONLY` environment variable like so:
+If you only want to receive answers from the edge model, you can set the `EDGE_ONLY` environment variable in [the edge deployment YAML file](/edge-endpoint/deploy/k3s/edge_deployment/edge_deployment.yaml) like so:
 ```
-export EDGE_ONLY=ENABLED
+- name: EDGE_ONLY
+    value: "ENABLED"
 ```
-Then, if you make requests to the edge endpoint using the `ask_async` method, you will only receive answers from the edge model (regardless of the confidence). Additionally, note that no image queries submitted this way will show up in the web app or be used to train the model. This option should therefore only be used if you don't need the model to improve, and only want fast answers from the edge model.
+Then, if you make requests to the edge endpoint using the `ask_async` method, you will only receive answers from the edge model (regardless of the confidence). Additionally, note that no image queries submitted this way will show up in the web app or be used to train the model. This option should therefore only be used if you don't need the model to improve and only want fast answers from the edge model.
 
-This is an experimental feature and may be modified or removed in the future.
+This is an experimental feature and may be modified or removed in the future. `EDGE_ONLY` is disabled by default.
 
 ## Development and Internal Architecture
 

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -64,7 +64,7 @@ def handle_iqe_creation(
     app_state: AppState,
 ) -> ImageQuery:
     """
-    Handles the creation of an edge image query.
+    Handles the creation of an edge image query from the model results.
 
     :param detector_id: The string id of the detector to use
     :param results: A dict containing the results from the model.

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -109,7 +109,7 @@ async def post_image_query(
         },
     )
 
-    edge_only = os.environ.get("EDGE_ONLY", "") == "ENABLED"
+    edge_only = bool(int(os.environ.get("EDGE_ONLY", 0)))
 
     # TODO: instead of just forwarding want_async calls to the cloud, facilitate partial
     #       processing of the async request on the edge before escalating to the cloud.

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -167,12 +167,12 @@ async def post_image_query(
         confidence = results["confidence"]
 
         if (
+            edge_only or
             _is_confident_enough(
                 confidence=confidence,
                 detector_metadata=get_detector_metadata(detector_id=detector_id, gl=gl),
                 confidence_threshold=confidence_threshold,
             )
-            or edge_only
         ):
             if edge_only:
                 logger.info("EDGE_ONLY is enabled. The edge model's answer will be returned regardless of confidence.")

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -137,7 +137,7 @@ async def post_image_query(
         # NOTE: because this is temporary code, this skips handling motion detection
 
         if not edge_inference_manager.inference_is_available(detector_id=detector_id):
-            raise ValueError("EDGE_ONLY is set to ENABLED, but edge inference is not available.")
+            raise RuntimeError("EDGE_ONLY is set to ENABLED, but edge inference is not available.")
 
         logger.debug(
             "EDGE_ONLY is set to ENABLED. This async request will not be escalated to the cloud and the "

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -166,13 +166,10 @@ async def post_image_query(
         results = edge_inference_manager.run_inference(detector_id=detector_id, img_numpy=img_numpy)
         confidence = results["confidence"]
 
-        if (
-            edge_only or
-            _is_confident_enough(
-                confidence=confidence,
-                detector_metadata=get_detector_metadata(detector_id=detector_id, gl=gl),
-                confidence_threshold=confidence_threshold,
-            )
+        if edge_only or _is_confident_enough(
+            confidence=confidence,
+            detector_metadata=get_detector_metadata(detector_id=detector_id, gl=gl),
+            confidence_threshold=confidence_threshold,
         ):
             if edge_only:
                 logger.info("EDGE_ONLY is enabled. The edge model's answer will be returned regardless of confidence.")

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -107,7 +107,7 @@ async def post_image_query(
             "inspection_id",  # inspection_id will not be supported on the edge
             "metadata",  # metadata is not supported on the edge currently, we need to set up persistent storage first
         },
-    ))
+    )
 
     img_numpy = np.asarray(image)  # [H, W, C=3], dtype: uint8, RGB format
 

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -54,12 +54,13 @@ async def validate_query_params_for_edge(request: Request, invalid_edge_params: 
             detail=f"Invalid query parameters for submit_image_query to edge-endpoint: {invalid_provided_params}",
         )
 
+
 def handle_iqe_creation(
     detector_id: str,
     results: dict,
     detector_metadata: Detector,
-    patience_time: float | None, 
-    confidence_threshold: float | None, 
+    patience_time: float | None,
+    confidence_threshold: float | None,
     app_state: AppState,
 ) -> ImageQuery:
     """
@@ -91,6 +92,7 @@ def handle_iqe_creation(
     app_state.db_manager.create_iqe_record(record=image_query)
 
     return image_query
+
 
 @router.post("", response_model=ImageQuery)
 async def post_image_query(
@@ -175,12 +177,12 @@ async def post_image_query(
 
         if not edge_inference_manager.inference_is_available(detector_id=detector_id):
             raise ValueError("EDGE_ONLY is set to ENABLED, but edge inference is not available.")
-        
+
         logger.debug(
             "EDGE_ONLY is set to ENABLED. This async request will not be escalated to the cloud and the "
             "edge model's answer will be returned regardless of confidence. Motion detection will be ignored."
         )
-        
+
         detector_metadata: Detector = get_detector_metadata(detector_id=detector_id, gl=gl)
         results = edge_inference_manager.run_inference(detector_id=detector_id, img_numpy=img_numpy)
 
@@ -190,7 +192,7 @@ async def post_image_query(
             detector_metadata=detector_metadata,
             patience_time=patience_time,
             confidence_threshold=confidence_threshold,
-            app_state=app_state
+            app_state=app_state,
         )
 
         return image_query
@@ -240,7 +242,7 @@ async def post_image_query(
                 detector_metadata=detector_metadata,
                 patience_time=patience_time,
                 confidence_threshold=confidence_threshold,
-                app_state=app_state
+                app_state=app_state,
             )
         else:
             logger.info(

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -114,7 +114,7 @@ async def post_image_query(
     # TODO: instead of just forwarding want_async calls to the cloud, facilitate partial
     #       processing of the async request on the edge before escalating to the cloud.
     _want_async = want_async is not None and want_async.lower() == "true"
-    if _want_async and not edge_only: # If edge-only mode is enabled, we don't want to make cloud API calls
+    if _want_async and not edge_only:  # If edge-only mode is enabled, we don't want to make cloud API calls
         return safe_call_api(
             gl.submit_image_query,
             detector=detector_id,
@@ -166,11 +166,14 @@ async def post_image_query(
         results = edge_inference_manager.run_inference(detector_id=detector_id, img_numpy=img_numpy)
         confidence = results["confidence"]
 
-        if _is_confident_enough(
-            confidence=confidence,
-            detector_metadata=get_detector_metadata(detector_id=detector_id, gl=gl),
-            confidence_threshold=confidence_threshold,
-        ) or edge_only:
+        if (
+            _is_confident_enough(
+                confidence=confidence,
+                detector_metadata=get_detector_metadata(detector_id=detector_id, gl=gl),
+                confidence_threshold=confidence_threshold,
+            )
+            or edge_only
+        ):
             if edge_only:
                 logger.info("EDGE_ONLY is enabled. The edge model's answer will be returned regardless of confidence.")
             else:

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -128,8 +128,8 @@ async def post_image_query(
 
     img_numpy = np.asarray(image)  # [H, W, C=3], dtype: uint8, RGB format
 
-    edge_inference_manager = app_state.edge_inference_manager
     motion_detection_manager = app_state.motion_detection_manager
+    edge_inference_manager = app_state.edge_inference_manager
     require_human_review = human_review == "ALWAYS"
 
     if not require_human_review and motion_detection_manager.motion_detection_is_available(detector_id=detector_id):

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -1,6 +1,6 @@
 import logging
-from io import BytesIO
 import os
+from io import BytesIO
 from typing import Optional
 
 import numpy as np
@@ -166,7 +166,7 @@ async def post_image_query(
             motion_detection_manager.update_image_query_response(detector_id=detector_id, response=image_query)
 
         return image_query
-            
+
     if not require_human_review and motion_detection_manager.motion_detection_is_available(detector_id=detector_id):
         motion_detected = motion_detection_manager.run_motion_detection(detector_id=detector_id, new_img=img_numpy)
         if not motion_detected:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -36,7 +36,7 @@ a Groundlight API token in the [Groundlight web app](https://app.groundlight.ai/
 export GROUNDLIGHT_API_TOKEN="api_xxxxxx"
 
 # Choose an inference flavor, either CPU or (default) GPU.
-# Note that appropriate setup for GPU must be done separately.
+# Note that appropriate setup for GPU may need to be done separately.
 export INFERENCE_FLAVOR="CPU"
 # export INFERENCE_FLAVOR = "GPU"
 ```

--- a/deploy/k3s/edge_deployment/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment/edge_deployment.yaml
@@ -75,10 +75,10 @@ spec:
         # TODO: Once we have kubernetes-based tests, we can remove this feature flag.
         - name: DEPLOY_DETECTOR_LEVEL_INFERENCE
           value: "1"
-        # When this is set to ENABLED, ask_async calls to the edge endpoint will only return the edge model's answer,
-        # regardless of the confidence.
+        # When EDGE_ONLY is set to 1, requests to the edge endpoint will only return the edge model's answer, regardless
+        # of the confidence.
         - name: EDGE_ONLY
-          value: "" # disabled by default
+          value: "0" # disabled by default
         volumeMounts:
         - name: edge-config-volume
           mountPath: /etc/groundlight/edge-config

--- a/deploy/k3s/edge_deployment/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment/edge_deployment.yaml
@@ -75,6 +75,10 @@ spec:
         # TODO: Once we have kubernetes-based tests, we can remove this feature flag.
         - name: DEPLOY_DETECTOR_LEVEL_INFERENCE
           value: "1"
+        # When this is set to ENABLED, ask_async calls to the edge endpoint will only return the edge model's answer,
+        # regardless of the confidence.
+        - name: EDGE_ONLY
+          value: "" # disabled by default
         volumeMounts:
         - name: edge-config-volume
           mountPath: /etc/groundlight/edge-config


### PR DESCRIPTION
Adds an option to only receive answers from the edge model when using `ask_async`. This code is temporary and will be removed once there is a better way to support this functionality.