### PR TITLE
Enable per-detector edge-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,18 +50,27 @@ print(f"The answer is {image_query.result}")
 See the [SDK's getting started guide](https://code.groundlight.ai/python-sdk/docs/getting-started) for more info.
 
 ### Experimental: getting only edge model answers
-If you only want to receive answers from the edge model, you can set the `EDGE_ONLY` environment variable in [the edge deployment YAML file](/edge-endpoint/deploy/k3s/edge_deployment/edge_deployment.yaml) like so:
+If you only want to receive answers from the edge model for a detector, you can enable edge-only mode for it. To do this, edit the detector's configuration in the [edge config file](./configs/edge-config.yaml) like so:
 ```
-- name: EDGE_ONLY
-    value: "ENABLED"
-```
-Then, if you make requests to the edge endpoint, you will only receive answers from the edge model (regardless of the confidence). Additionally, note that no image queries submitted this way will show up in the web app or be used to train the model. This option should therefore only be used if you don't need the model to improve and only want fast answers from the edge model.
+detectors:
+  - detector_id: 'det_xyz'
+    motion_detection_template: "disabled"
+    local_inference_template: "default"
+    edge_only: true
 
-If this flag is enabled and the edge inference model for a detector is not available, attempting to send image queries to that detector will return a 500 error response.
+  - detector_id: 'det_abc'
+    motion_detection_template: "default"
+    local_inference_template: "default"
+```
+In this example, `det_xyz` will have edge-only mode enabled because `edge_only` is set to `true`. If `edge_only` is not specified, it defaults to false, so `det_abc` will have edge-only mode disabled.
+
+With edge-only mode enabled for a detector, when you make requests to it, you will only receive answers from the edge model (regardless of the confidence). Additionally, note that no image queries submitted this way will show up in the web app or be used to train the model. This option should therefore only be used if you don't need the model to improve and only want fast answers from the edge model.
+
+If edge-only mode is enabled on a detector and the edge inference model for that detector is not available, attempting to send image queries to that detector will return a 500 error response.
 
 This feature is currently not fully compatible with motion detection. If motion detection is enabled, some image queries may still be sent to the cloud API.
 
-This is an experimental feature and may be modified or removed in the future. `EDGE_ONLY` is disabled by default.
+This is an experimental feature and may be modified or removed in the future.
 
 ## Development and Internal Architecture
 

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -135,7 +135,7 @@ async def post_image_query(
 
     if not require_human_review and motion_detection_manager.motion_detection_is_available(detector_id=detector_id):
         motion_detected = motion_detection_manager.run_motion_detection(detector_id=detector_id, new_img=img_numpy)
-        # TODO motion detection logic will likely need to be altered to work with the EDGE_ONLY flag
+        # TODO motion detection logic will likely need to be altered to work with edge-only mode
         if not motion_detected:
             # Try improving the cached image query response's confidence
             # (if the cached response has low confidence)
@@ -173,7 +173,10 @@ async def post_image_query(
             confidence_threshold=confidence_threshold,
         ):
             if edge_only:
-                logger.info("EDGE_ONLY is enabled. The edge model's answer will be returned regardless of confidence.")
+                logger.info(
+                    "Edge-only mode is enabled on this detector. The edge model's answer will be returned "
+                    "regardless of confidence."
+                )
             else:
                 logger.info("Edge detector confidence is high enough to return")
 
@@ -212,7 +215,7 @@ async def post_image_query(
 
         # Fail if edge inference is not available and edge-only mode is enabled
         if edge_only:
-            raise RuntimeError("EDGE_ONLY is set to ENABLED, but edge inference is not available.")
+            raise RuntimeError("Edge-only mode is enabled on this detector, but edge inference is not available.")
 
     # Finally, fall back to submitting the image to the cloud
     if not image_query:

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from io import BytesIO
 from typing import Optional
 
@@ -16,7 +15,7 @@ from app.core.app_state import (
     get_detector_metadata,
     get_groundlight_sdk_instance,
 )
-from app.core.configs import DetectorConfig, RootEdgeConfig
+from app.core.configs import DetectorConfig
 from app.core.motion_detection import MotionDetectionManager
 from app.core.utils import create_iqe, prefixed_ksuid, safe_call_api
 
@@ -54,6 +53,7 @@ async def validate_query_params_for_edge(request: Request, invalid_edge_params: 
             status_code=400,
             detail=f"Invalid query parameters for submit_image_query to edge-endpoint: {invalid_provided_params}",
         )
+
 
 @router.post("", response_model=ImageQuery)
 async def post_image_query(
@@ -254,19 +254,21 @@ async def get_image_query(
         return image_query
     return safe_call_api(gl.get_image_query, id=id)
 
+
 def _get_detector_config_by_id(detector_configs: list[DetectorConfig], detector_id: str) -> DetectorConfig | None:
     """
     Finds the corresponding `DetectorConfig` for the given detector id from the list.
 
-    :param detector_configs: A list of `DetectorConfig`. 
+    :param detector_configs: A list of `DetectorConfig`.
     :param detector_id: The detector_id string to look for.
     :returns: The corresponding `DetectorConfig` if it exists, and None if there is no matching config.
     """
     for detector_config in detector_configs:
         if detector_id == detector_config.detector_id:
             return detector_config
-    
+
     return None
+
 
 def _improve_cached_image_query_confidence(
     gl: Groundlight,

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -15,7 +15,6 @@ from app.core.app_state import (
     get_detector_metadata,
     get_groundlight_sdk_instance,
 )
-from app.core.configs import DetectorConfig
 from app.core.motion_detection import MotionDetectionManager
 from app.core.utils import create_iqe, prefixed_ksuid, safe_call_api
 

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -109,7 +109,7 @@ async def post_image_query(
         },
     )
 
-    detector_config = _get_detector_config_by_id(app_state.edge_config.detectors, detector_id)
+    detector_config = app_state.edge_config.detectors.get(detector_id, None)
     edge_only = detector_config.edge_only if detector_config is not None else False
 
     # TODO: instead of just forwarding want_async calls to the cloud, facilitate partial
@@ -253,21 +253,6 @@ async def get_image_query(
             raise HTTPException(status_code=404, detail=f"Image query with ID {id} not found")
         return image_query
     return safe_call_api(gl.get_image_query, id=id)
-
-
-def _get_detector_config_by_id(detector_configs: list[DetectorConfig], detector_id: str) -> DetectorConfig | None:
-    """
-    Finds the corresponding `DetectorConfig` for the given detector id from the list.
-
-    :param detector_configs: A list of `DetectorConfig`.
-    :param detector_id: The detector_id string to look for.
-    :returns: The corresponding `DetectorConfig` if it exists, and None if there is no matching config.
-    """
-    for detector_config in detector_configs:
-        if detector_id == detector_config.detector_id:
-            return detector_config
-
-    return None
 
 
 def _improve_cached_image_query_confidence(

--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -50,13 +50,13 @@ def _load_config_from_yaml(yaml_config) -> RootEdgeConfig:
 
     detectors = config.get("detectors", [])
     detector_ids = [det["detector_id"] for det in detectors]
-    
+
     # Check for duplicate detector IDs
     if len(detector_ids) != len(set(detector_ids)):
         raise ValueError("Duplicate detector IDs found in the configuration. Each detector should only have one entry.")
-    
+
     config["detectors"] = {det["detector_id"]: det for det in detectors}
-    
+
     return RootEdgeConfig(**config)
 
 

--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -63,7 +63,8 @@ def get_inference_and_motion_detection_configs(
             for detector_id, detector_config in detectors.items()
         }
         inference_config: Dict[str, LocalInferenceConfig] = {
-            detector_id: edge_inference_templates[detector_config.local_inference_template] for detector_id, detector_config in detectors.items()
+            detector_id: edge_inference_templates[detector_config.local_inference_template]
+            for detector_id, detector_config in detectors.items()
         }
 
     return inference_config, motion_detection_config

--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -31,6 +31,7 @@ def load_edge_config() -> RootEdgeConfig:
     yaml_config = os.environ.get("EDGE_CONFIG", "").strip()
     if yaml_config:
         config = yaml.safe_load(yaml_config)
+        config["detectors"] = {det["detector_id"]: det for det in config.get("detectors", [])}
         return RootEdgeConfig(**config)
 
     logger.warning("EDGE_CONFIG environment variable not set. Checking default locations.")
@@ -39,6 +40,7 @@ def load_edge_config() -> RootEdgeConfig:
         logger.info(f"Loading edge config from {DEFAULT_EDGE_CONFIG_PATH}")
         with open(DEFAULT_EDGE_CONFIG_PATH, "r") as f:
             config = yaml.safe_load(f)
+            config["detectors"] = {det["detector_id"]: det for det in config.get("detectors", [])}
         return RootEdgeConfig(**config)
 
     raise FileNotFoundError(f"Could not find edge config file in default location: {DEFAULT_EDGE_CONFIG_PATH}")
@@ -51,17 +53,17 @@ def get_inference_and_motion_detection_configs(
     edge_inference_templates: Dict[str, LocalInferenceConfig] = root_edge_config.local_inference_templates
 
     # Filter out detectors whose ID's are empty strings
-    detectors = list(filter(lambda detector: detector.detector_id != "", root_edge_config.detectors))
+    detectors = {det_id: detector for det_id, detector in root_edge_config.detectors.items() if det_id != ""}
 
     motion_detection_config = None
     inference_config = None
     if detectors:
         motion_detection_config: Dict[str, MotionDetectionConfig] = {
-            detector.detector_id: motion_detection_templates[detector.motion_detection_template]
-            for detector in detectors
+            detector_id: motion_detection_templates[detector_config.motion_detection_template]
+            for detector_id, detector_config in detectors.items()
         }
         inference_config: Dict[str, LocalInferenceConfig] = {
-            detector.detector_id: edge_inference_templates[detector.local_inference_template] for detector in detectors
+            detector_id: edge_inference_templates[detector_config.local_inference_template] for detector_id, detector_config in detectors.items()
         }
 
     return inference_config, motion_detection_config

--- a/app/core/configs.py
+++ b/app/core/configs.py
@@ -72,7 +72,7 @@ class RootEdgeConfig(BaseModel):
     ):
         """
         Validate the templates referenced by the detectors.
-        :param detector: The detector to validate.
+        :param detectors: The detectors to validate.
         :param values: The values passed to the validator. This is a dictionary of the form:
             {
                 'motion_detection_templates': {
@@ -91,6 +91,8 @@ class RootEdgeConfig(BaseModel):
                 }
             }
         """
+        logger.info(f"detectors has type {type(detectors)}")
+        logger.info(f"first value in detectors has type {type(list(detectors.values())[0])}")
         for detector in detectors.values():
             if (
                 "motion_detection_templates" in values

--- a/app/core/configs.py
+++ b/app/core/configs.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional, Union
+from typing import Dict, Optional, Union
 
 from pydantic import BaseModel, Field, validator
 
@@ -66,7 +66,9 @@ class RootEdgeConfig(BaseModel):
 
     @validator("detectors", pre=True, each_item=False)
     def validate_templates(
-        cls, detectors: Dict[str, DetectorConfig], values: Dict[str, Dict[str, Union[MotionDetectionConfig, LocalInferenceConfig]]]
+        cls,
+        detectors: Dict[str, DetectorConfig],
+        values: Dict[str, Dict[str, Union[MotionDetectionConfig, LocalInferenceConfig]]],
     ):
         """
         Validate the templates referenced by the detectors.

--- a/app/core/configs.py
+++ b/app/core/configs.py
@@ -50,6 +50,7 @@ class DetectorConfig(BaseModel):
     detector_id: str = Field(..., description="Detector ID")
     local_inference_template: str = Field(..., description="Template for local edge inference.")
     motion_detection_template: str = Field(..., description="Template for motion detection.")
+    edge_only: bool = Field(False, description="Whether the detector should be in edge-only mode or not.")
 
 
 class RootEdgeConfig(BaseModel):

--- a/app/core/configs.py
+++ b/app/core/configs.py
@@ -64,7 +64,7 @@ class RootEdgeConfig(BaseModel):
     local_inference_templates: Dict[str, LocalInferenceConfig]
     detectors: Dict[str, DetectorConfig]
 
-    @validator("detectors", pre=True, each_item=False)
+    @validator("detectors", each_item=False)
     def validate_templates(
         cls,
         detectors: Dict[str, DetectorConfig],

--- a/app/core/configs.py
+++ b/app/core/configs.py
@@ -62,11 +62,11 @@ class RootEdgeConfig(BaseModel):
 
     motion_detection_templates: Dict[str, MotionDetectionConfig]
     local_inference_templates: Dict[str, LocalInferenceConfig]
-    detectors: List[DetectorConfig]
+    detectors: Dict[str, DetectorConfig]
 
-    @validator("detectors", each_item=True)
+    @validator("detectors", pre=True, each_item=False)
     def validate_templates(
-        cls, detector: DetectorConfig, values: Dict[str, Dict[str, Union[MotionDetectionConfig, LocalInferenceConfig]]]
+        cls, detectors: Dict[str, DetectorConfig], values: Dict[str, Dict[str, Union[MotionDetectionConfig, LocalInferenceConfig]]]
     ):
         """
         Validate the templates referenced by the detectors.
@@ -89,15 +89,15 @@ class RootEdgeConfig(BaseModel):
                 }
             }
         """
-
-        if (
-            "motion_detection_templates" in values
-            and detector.motion_detection_template not in values["motion_detection_templates"]
-        ):
-            raise ValueError(f"Motion Detection Template {detector.motion_detection_template} not defined.")
-        if (
-            "local_inference_templates" in values
-            and detector.local_inference_template not in values["local_inference_templates"]
-        ):
-            raise ValueError(f"Local Inference Template {detector.local_inference_template} not defined.")
-        return detector
+        for detector in detectors.values():
+            if (
+                "motion_detection_templates" in values
+                and detector.motion_detection_template not in values["motion_detection_templates"]
+            ):
+                raise ValueError(f"Motion Detection Template {detector.motion_detection_template} not defined.")
+            if (
+                "local_inference_templates" in values
+                and detector.local_inference_template not in values["local_inference_templates"]
+            ):
+                raise ValueError(f"Local Inference Template {detector.local_inference_template} not defined.")
+        return detectors

--- a/app/core/configs.py
+++ b/app/core/configs.py
@@ -93,6 +93,7 @@ class RootEdgeConfig(BaseModel):
         """
         logger.info(f"detectors has type {type(detectors)}")
         logger.info(f"first value in detectors has type {type(list(detectors.values())[0])}")
+        logger.info(f"first value in detectors is: {list(detectors.values())[0]}")
         for detector in detectors.values():
             if (
                 "motion_detection_templates" in values

--- a/app/core/configs.py
+++ b/app/core/configs.py
@@ -91,9 +91,6 @@ class RootEdgeConfig(BaseModel):
                 }
             }
         """
-        logger.info(f"detectors has type {type(detectors)}")
-        logger.info(f"first value in detectors has type {type(list(detectors.values())[0])}")
-        logger.info(f"first value in detectors is: {list(detectors.values())[0]}")
         for detector in detectors.values():
             if (
                 "motion_detection_templates" in values

--- a/app/core/configs.py
+++ b/app/core/configs.py
@@ -50,7 +50,9 @@ class DetectorConfig(BaseModel):
     detector_id: str = Field(..., description="Detector ID")
     local_inference_template: str = Field(..., description="Template for local edge inference.")
     motion_detection_template: str = Field(..., description="Template for motion detection.")
-    edge_only: bool = Field(False, description="Whether the detector should be in edge-only mode or not.")
+    edge_only: bool = Field(
+        False, description="Whether the detector should be in edge-only mode or not. Optional; defaults to False."
+    )
 
 
 class RootEdgeConfig(BaseModel):

--- a/deploy/k3s/edge_deployment/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment/edge_deployment.yaml
@@ -75,10 +75,6 @@ spec:
         # TODO: Once we have kubernetes-based tests, we can remove this feature flag.
         - name: DEPLOY_DETECTOR_LEVEL_INFERENCE
           value: "1"
-        # When EDGE_ONLY is set to 1, requests to the edge endpoint will only return the edge model's answer, regardless
-        # of the confidence.
-        - name: EDGE_ONLY
-          value: "0" # disabled by default
         volumeMounts:
         - name: edge-config-volume
           mountPath: /etc/groundlight/edge-config

--- a/test/api/test_motdet.py
+++ b/test/api/test_motdet.py
@@ -32,7 +32,7 @@ def root_config() -> RootEdgeConfig:
 
 
 def motion_detection_enabled(config: RootEdgeConfig) -> bool:
-    configured_detector_ids = [detector.detector_id for detector in config.detectors]
+    configured_detector_ids = list(config.detectors.keys())
 
     testing_detector_ids = [detector["detector_id"] for detector in DETECTORS.values()]
     return all(id_ in configured_detector_ids for id_ in testing_detector_ids)


### PR DESCRIPTION
Changes edge-only mode from being a global environment variable to being detector specific and configured in the `edge-config.yaml` file. 

Also makes `DetectorConfig`s be stored as a dict instead of a list.

See README for usage.