### PR TITLE
Configuring EE proxy for multiple workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ COPY --from=production-dependencies-build-stage ${APP_ROOT}/configs/nginx.conf /
 # Remove default nginx config
 RUN rm /etc/nginx/sites-enabled/default
 
-CMD nginx && poetry run uvicorn --workers 1 --host 0.0.0.0 --port ${APP_PORT} --proxy-headers app.main:app
+CMD nginx && poetry run uvicorn --workers 8 --host 0.0.0.0 --port ${APP_PORT} --proxy-headers app.main:app
 
 # Document the exposed port which was configured in start_uvicorn.sh
 # https://docs.docker.com/engine/reference/builder/#expose


### PR DESCRIPTION
We only had 1 python worker on the EE proxy process before.  This might overwhelm the models, but seems like something we want overall.