### PR TITLE
Fix deployment bug for unconfigured detectors; reset database upon startup

### DIFF
--- a/app/core/configs.py
+++ b/app/core/configs.py
@@ -32,14 +32,13 @@ class LocalInferenceConfig(BaseModel):
     Configuration for local edge inference on a specific detector.
     """
 
-    enabled: bool = Field(False, description="Determines if local edge inference is enabled for a specific detector.")
-    api_token: Optional[str] = Field(None, description="API token to fetch the inference model for this detector.")
-    refresh_rate: float = Field(
-        default=120.0,
-        description=(
-            "The refresh rate for the inference server (in seconds). This means how often to check for an updated model"
-            " binary."
-        ),
+    enabled: bool = Field(default=False, description="True if edge-inference is enabled for a specific detector.")
+    api_token: Optional[str] = Field(
+        default=None, description="API token used to fetch the inference model for this detector."
+    )
+    refresh_rate: float = Field(  # TODO: this field is not used on a per-detector basis, remove it
+        default=60,
+        description="The interval (in seconds) at which the inference server checks for a new model binary update.",
     )
 
 

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -120,12 +120,6 @@ class DatabaseManager:
             query_results = session.execute(query)
             return query_results.scalars().all()
 
-    def delete_inference_deployment_records(self) -> None:
-        """Delete all records in the `inference_deployments` table."""
-        with self.session_maker() as session:
-            session.query(InferenceDeployment).delete()
-            session.commit()
-
     def create_iqe_record(self, iq: ImageQuery) -> None:
         """
         Creates a new record in the `image_queries_edge` table.
@@ -153,6 +147,16 @@ class DatabaseManager:
         """Create the database tables, if they don't already exist."""
         with self._engine.begin() as connection:
             Base.metadata.create_all(connection)
+
+    def drop_tables(self) -> None:
+        """Drop all tables in the database."""
+        with self._engine.begin() as connection:
+            Base.metadata.drop_all(connection)
+
+    def reset_database(self) -> None:
+        """Reset the database by deleting all tables and then recreating them."""
+        self.drop_tables()
+        self.create_tables()
 
     def shutdown(self) -> None:
         self._engine.dispose()

--- a/app/main.py
+++ b/app/main.py
@@ -39,7 +39,7 @@ def update_inference_config(app_state: AppState) -> None:
 async def startup_event():
     """Lifecycle event that is triggered when the application starts."""
     app.state.app_state = AppState()
-    app.state.app_state.db_manager.create_tables()  # ...if they don't already exist
+    app.state.app_state.db_manager.reset_database()
 
     if DEPLOY_DETECTOR_LEVEL_INFERENCE:
         # Add job to periodically update the inference config

--- a/app/main.py
+++ b/app/main.py
@@ -39,7 +39,7 @@ def update_inference_config(app_state: AppState) -> None:
 async def startup_event():
     """Lifecycle event that is triggered when the application starts."""
     app.state.app_state = AppState()
-    app.state.app_state.db_manager.reset_database()
+    app.state.app_state.db_manager.create_tables()  # ...if they don't already exist
 
     if DEPLOY_DETECTOR_LEVEL_INFERENCE:
         # Add job to periodically update the inference config
@@ -54,7 +54,6 @@ async def startup_event():
 async def shutdown_event():
     """Lifecycle event that is triggered when the application is shutting down."""
     app.state.app_state.is_ready = False
-    app.state.app_state.db_manager.drop_tables()
     app.state.app_state.db_manager.shutdown()
     if DEPLOY_DETECTOR_LEVEL_INFERENCE:
         scheduler.shutdown()

--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,7 @@ scheduler = AsyncIOScheduler()
 
 def update_inference_config(app_state: AppState) -> None:
     """Update the App's edge-inference config by querying the database for new detectors."""
-    detectors = app_state.db_manager.get_inference_deployments(deployment_created=True)
+    detectors = app_state.db_manager.get_inference_deployment_records(deployment_created=True)
     if detectors:
         for detector_record in detectors:
             app_state.edge_inference_manager.update_inference_config(
@@ -40,6 +40,7 @@ async def startup_event():
     """Lifecycle event that is triggered when the application starts."""
     app.state.app_state = AppState()
     app.state.app_state.db_manager.create_tables()  # ...if they don't already exist
+    app.state.app_state.db_manager.delete_inference_deployment_records()  # ...so they can be re-created
 
     if DEPLOY_DETECTOR_LEVEL_INFERENCE:
         # Add job to periodically update the inference config

--- a/app/main.py
+++ b/app/main.py
@@ -39,8 +39,7 @@ def update_inference_config(app_state: AppState) -> None:
 async def startup_event():
     """Lifecycle event that is triggered when the application starts."""
     app.state.app_state = AppState()
-    app.state.app_state.db_manager.create_tables()  # ...if they don't already exist
-    app.state.app_state.db_manager.delete_inference_deployment_records()  # ...so they can be re-created
+    app.state.app_state.db_manager.reset_database()
 
     if DEPLOY_DETECTOR_LEVEL_INFERENCE:
         # Add job to periodically update the inference config
@@ -55,6 +54,7 @@ async def startup_event():
 async def shutdown_event():
     """Lifecycle event that is triggered when the application is shutting down."""
     app.state.app_state.is_ready = False
+    app.state.app_state.db_manager.drop_tables()
     app.state.app_state.db_manager.shutdown()
     if DEPLOY_DETECTOR_LEVEL_INFERENCE:
         scheduler.shutdown()

--- a/configs/edge-config.yaml
+++ b/configs/edge-config.yaml
@@ -25,8 +25,8 @@ motion_detection_templates:
 local_inference_templates:
   default:
     enabled: true
-    # How often to fetch a new model binary (in seconds)
-    refresh_rate: 120
+    # How often to attempt to fetch a new ml model binary (in seconds)
+    refresh_rate: 60
 
   disabled:
     enabled: false

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,19 +3,19 @@
 
 The edge endpoint is run as a k3s deployment. Follow the steps below to get it set up.
 
-## Starting the k3s Cluster 
+## Starting the k3s Cluster
 
-If you don't have [k3s](https://docs.k3s.io/) installed, go ahead and install it by running 
+If you don't have [k3s](https://docs.k3s.io/) installed, go ahead and install it by running
 
 ```shell
 > ./deploy/bin/install-k3s.sh
 ```
 
 
-If you intend to run motion detection, make sure to add the detector ID's to the 
+If you intend to run motion detection, make sure to add the detector ID's to the
 [edge config file](../configs/edge-config.yaml). For edge inference, adding detector ID's to the config file will cause
-inference pods to be initialized automatically for each detector. Even if they aren't configured in the config file, 
-edge inference will be set up for each detector ID for which the Groundlight service receives requests (note that it 
+inference pods to be initialized automatically for each detector. Even if they aren't configured in the config file,
+edge inference will be set up for each detector ID for which the Groundlight service receives requests (note that it
 takes some time for each inference pod to become available the first time).
 
 Before starting the cluster, you need to create/specify the namespace for the deployment. If you're creating a new one, run:
@@ -43,16 +43,9 @@ export INFERENCE_FLAVOR="CPU"
 
 You'll also need to configure your AWS credentials using `aws configure` to include credentials that have permissions to pull from the appropriate ECR location (if you don't already have the AWS CLI installed, refer to the instructions [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)).
 
-To start the cluster, run 
-```shell 
-./deploy/bin/cluster_setup.sh
-```
-
-Sometimes it might be desirable to reset all database tables(i.e., delete all existing data) for a fresh start. In that case, 
-you will need to start the cluster with an extra argument:
-
+To start the cluster, run
 ```shell
-./deploy/bin/cluster_setup.sh db_reset
+./deploy/bin/cluster_setup.sh
 ```
 
 This will create the edge-endpoint deployment with two containers: one for the edge logic and another one for creating/updating inference
@@ -72,23 +65,21 @@ inferencemodel-det-3jemxiunjuekdjzbuxavuevw15k-5d8b454bcb-xqf8m   1/1     Runnin
 ```
 
 
-We currently have a hard-coded docker image from ECR in the [edge-endpoint](/edge-endpoint/deploy/k3s/edge_deployment.yaml) 
-deployment. If you want to make modifications to the edge endpoint code and push a different 
+We currently have a hard-coded docker image from ECR in the [edge-endpoint](/edge-endpoint/deploy/k3s/edge_deployment.yaml)
+deployment. If you want to make modifications to the edge endpoint code and push a different
 image to ECR see [Pushing/Pulling Images from ECR](#pushingpulling-images-from-elastic-container-registry-ecr).
 
 
 ## Pushing/Pulling Images from Elastic Container Registry (ECR)
 
-We currently have a hard-coded docker image in our k3s deployment, which is not ideal. 
+We currently have a hard-coded docker image in our k3s deployment, which is not ideal.
 If you're testing things locally and want to use a different docker image, you can do so
-by first creating a docker image locally, pushing it to ECR, retrieving the image ID and 
-then using that ID in the [edge_deployment](k3s/edge_deployment/edge_deployment.yaml) file. 
+by first creating a docker image locally, pushing it to ECR, retrieving the image ID and
+then using that ID in the [edge_deployment](k3s/edge_deployment/edge_deployment.yaml) file.
 
 Follow the following steps:
 
 ```shell
 # Build and push image to ECR
-> ./deploy/bin/build-push-edge-endpoint-image.sh 
+> ./deploy/bin/build-push-edge-endpoint-image.sh
 ```
-
-

--- a/deploy/bin/cluster_setup.sh
+++ b/deploy/bin/cluster_setup.sh
@@ -1,25 +1,19 @@
 #!/bin/bash
 
-# How to use this script:
-# ./deploy/bin/cluster_setup.sh [db_reset]
+# Usage:
+# Execute the script using the following command:
+# ./deploy/bin/cluster_setup.sh
 #
-# The optional argument "db_reset" will delete all the data in the database.
-# For now, this means all
-# - detectors in the `inference_deployments` table
-# - image queries in the `image_queries_edge` table
-# For more on these tables you can examine the database file at
-# /opt/groundlight/edge/sqlite/sqlite.db on the attached volume (EFS/local).
-
-# Possible env vars:
-# - KUBECTL_CMD: path to kubectl command. Defaults to "kubectl" but can be set to "k3s kubectl" if using k3s
-# - INFERENCE_FLAVOR: "CPU" or "GPU". Defaults to "GPU"
-# - EDGE_CONFIG: contents of edge-config.yaml. If not set, will use configs/edge-config.yaml
-# - DEPLOY_LOCAL_VERSION: Indicates whether we are building the local version of the edge endpoint.
-#           If set to 0, we will attach an EFS instead of a local volume. Defaults to 1.
-# - EFS_VOLUME_ID: ID of the EFS volume to use if we are using the EFS version.
-# - DEPLOYMENT_NAMESPACE: Namespace to deploy to. Defaults to the current namespace.
-# - RUN_EDGE_ENDPOINT: Indicates whether or not to launch the edge endpoint pods.
-#           If set, launch edge-endpoint pods. If not set, do not launch pods.
+# Environment Variables:
+# - KUBECTL_CMD: Specifies the path to the kubectl command. Defaults to "kubectl". If using k3s, set to "k3s kubectl".
+# - INFERENCE_FLAVOR: Determines the inference type, either "CPU" or "GPU". Defaults to "GPU".
+# - EDGE_CONFIG: Specifies the contents of edge-config.yaml. If not set, defaults to configs/edge-config.yaml.
+# - DEPLOY_LOCAL_VERSION: Indicates if the local version of the edge endpoint is being built.
+#   - Set to 0 to attach an EFS instead of a local volume. Defaults to 1.
+# - EFS_VOLUME_ID: The ID of the EFS volume to use when deploying the EFS version.
+# - DEPLOYMENT_NAMESPACE: The namespace for deployment. Defaults to the current namespace.
+# - RUN_EDGE_ENDPOINT: Controls the launch of edge endpoint pods.
+#   - If set, the edge-endpoint pods will be launched. If not set, pods will not be launched.
 
 set -ex
 
@@ -64,7 +58,6 @@ echo "RUN_EDGE_ENDPOINT is set to '${RUN_EDGE_ENDPOINT}'. Starting edge endpoint
 
 K=${KUBECTL_CMD:-"kubectl"}
 INFERENCE_FLAVOR=${INFERENCE_FLAVOR:-"GPU"}
-DB_RESET=$1
 DEPLOY_LOCAL_VERSION=${DEPLOY_LOCAL_VERSION:-1}
 DEPLOYMENT_NAMESPACE=${DEPLOYMENT_NAMESPACE:-$($K config view -o json | jq -r '.contexts[] | select(.name == "'$($K config current-context)'") | .context.namespace // "default"')}
 
@@ -121,13 +114,6 @@ fi
 $K create configmap kubernetes-namespace --from-literal=namespace=${DEPLOYMENT_NAMESPACE}
 
 $K create configmap setup-db --from-file=$(pwd)/deploy/bin/setup_db.sh -n ${DEPLOYMENT_NAMESPACE}
-
-# If db_reset is passed as an argument, create a environment variable DB_RESET
-if [[ "$DB_RESET" == "db_reset" ]]; then
-    $K create configmap db-reset --from-literal=DB_RESET=1
-else
-    $K create configmap db-reset --from-literal=DB_RESET=0
-fi
 
 # Clean up existing deployments and services (if they exist)
 $K delete --ignore-not-found deployment edge-endpoint

--- a/deploy/bin/cluster_setup.sh
+++ b/deploy/bin/cluster_setup.sh
@@ -132,6 +132,7 @@ fi
 # Clean up existing deployments and services (if they exist)
 $K delete --ignore-not-found deployment edge-endpoint
 $K delete --ignore-not-found service edge-endpoint-service
+$K delete --ignore-not-found deployment warmup-inference-model
 $K get deployments -o custom-columns=":metadata.name" --no-headers=true | \
     grep "inferencemodel" | \
     xargs -I {} $K delete deployments {}

--- a/deploy/bin/dbshell.sh
+++ b/deploy/bin/dbshell.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# requires sqlite3 to be installed
+# sudo apt install sqlite3
+
+sqlite3 -header -column /opt/groundlight/edge/sqlite.db
+# .help for help
+# .quit or .exit 0 to exit

--- a/deploy/bin/setup_db.sh
+++ b/deploy/bin/setup_db.sh
@@ -1,33 +1,14 @@
 #!/bin/bash
 
 # Sets up the SQLite database for the edge endpoint.
-# Expects the following environment variables:
-# - DB_RESET: If set to 1, will delete all the data in the database.
-#
 # This script is invoked by an initContainer in the edge endpoint deployment.
 
-set -ex 
-
-DB_RESET=${DB_RESET:-0}
+set -ex
 
 DATABASE_DIRECTORY="/opt/groundlight/edge/sqlite"
 DATABASE_PATH="${DATABASE_DIRECTORY}/sqlite.db"
 ENTRY_QUERY="CREATE TABLE IF NOT EXISTS test_table (id INTEGER);"
 DROP_QUERY="DROP TABLE IF EXISTS test_table;"
-
-
-reset_tables() {
-    TABLES=( "inference_deployments" "image_queries_edge" )
-
-    for TABLE_NAME in "${TABLES[@]}"; do
-        if [[ $(sqlite3 "${DATABASE_PATH}" "SELECT name FROM sqlite_master WHERE type='table' AND name='${TABLE_NAME}';") == "${TABLE_NAME}" ]]; then
-            echo "${TABLE_NAME} table exists. Deleting records..."
-            sqlite3 "${DATABASE_PATH}" "DELETE FROM ${TABLE_NAME};"
-        else
-            echo "${TABLE_NAME} table doesn't exist."
-        fi
-    done
-}
 
 echo "Using sqlite3 from $(which sqlite3)"
 
@@ -40,19 +21,14 @@ else
     mkdir -p ${DATABASE_DIRECTORY}
     chown -R "$(id -u)":"$(id -g)" "${DATABASE_DIRECTORY}"
 
-    # SQLite is eccentric in a sense that if you just invoke `sqlite3 <db_file>`, it won't 
-    # actually create the file. We are using a hack here to initialize the database with 
-    # a test table and then drop it. 
+    # SQLite is eccentric in a sense that if you just invoke `sqlite3 <db_file>`, it won't
+    # actually create the file. We are using a hack here to initialize the database with
+    # a test table and then drop it.
     echo "${ENTRY_QUERY}" | sqlite3 "${DATABASE_PATH}"
     echo "${DROP_QUERY}" | sqlite3 "${DATABASE_PATH}"
 
-    # Set journal mode to Write-Ahead Logging. This makes it much faster, at the risk of 
+    # Set journal mode to Write-Ahead Logging. This makes it much faster, at the risk of
     # possibly losing data if the machine crashes suddenly.
     # https://www.sqlite.org/wal.html
     echo "PRAGMA journal_mode=WAL;" | sqlite3 "${DATABASE_PATH}"
-fi
-
-if [[ "${DB_RESET}" == "1" ]]; then
-    echo "Resetting tables..."
-    reset_tables
 fi

--- a/deploy/bin/setup_db.sh
+++ b/deploy/bin/setup_db.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Sets up the SQLite database for the edge endpoint.
+# Set up the SQLite database for the edge endpoint.
 # This script is invoked by an initContainer in the edge endpoint deployment.
 
 set -ex
@@ -12,23 +12,25 @@ DROP_QUERY="DROP TABLE IF EXISTS test_table;"
 
 echo "Using sqlite3 from $(which sqlite3)"
 
-
-# If the database already exists, exit. Otherwise, create it
+# Always remove the existing database file
 if [[ -f "${DATABASE_PATH}" ]]; then
-    echo "SQLite database file exists and is mounted correctly."
-else
-    echo "SQLite database file doesn't exist or wasn't mounted correctly. Creating it now..."
-    mkdir -p ${DATABASE_DIRECTORY}
-    chown -R "$(id -u)":"$(id -g)" "${DATABASE_DIRECTORY}"
-
-    # SQLite is eccentric in a sense that if you just invoke `sqlite3 <db_file>`, it won't
-    # actually create the file. We are using a hack here to initialize the database with
-    # a test table and then drop it.
-    echo "${ENTRY_QUERY}" | sqlite3 "${DATABASE_PATH}"
-    echo "${DROP_QUERY}" | sqlite3 "${DATABASE_PATH}"
-
-    # Set journal mode to Write-Ahead Logging. This makes it much faster, at the risk of
-    # possibly losing data if the machine crashes suddenly.
-    # https://www.sqlite.org/wal.html
-    echo "PRAGMA journal_mode=WAL;" | sqlite3 "${DATABASE_PATH}"
+    echo "Removing existing SQLite database file..."
+    rm -f "${DATABASE_PATH}"
 fi
+
+# Create the database directory if it doesn't exist
+mkdir -p ${DATABASE_DIRECTORY}
+chown -R "$(id -u)":"$(id -g)" "${DATABASE_DIRECTORY}"
+
+# SQLite is eccentric in a sense that if you just invoke `sqlite3 <db_file>`, it won't
+# actually create the file. We are using a hack here to initialize the database with
+# a test table and then drop it.
+echo "${ENTRY_QUERY}" | sqlite3 "${DATABASE_PATH}"
+echo "${DROP_QUERY}" | sqlite3 "${DATABASE_PATH}"
+
+# Set journal mode to Write-Ahead Logging. This makes it much faster, at the risk of
+# possibly losing data if the machine crashes suddenly.
+# https://www.sqlite.org/wal.html
+echo "PRAGMA journal_mode=WAL;" | sqlite3 "${DATABASE_PATH}"
+
+echo "SQLite database has been created."

--- a/deploy/bin/setup_db.sh
+++ b/deploy/bin/setup_db.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Set up the SQLite database for the edge endpoint.
+# Sets up the SQLite database for the edge endpoint.
 # This script is invoked by an initContainer in the edge endpoint deployment.
 
 set -ex
@@ -10,27 +10,25 @@ DATABASE_PATH="${DATABASE_DIRECTORY}/sqlite.db"
 ENTRY_QUERY="CREATE TABLE IF NOT EXISTS test_table (id INTEGER);"
 DROP_QUERY="DROP TABLE IF EXISTS test_table;"
 
+
 echo "Using sqlite3 from $(which sqlite3)"
 
-# Always remove the existing database file
+# If the database already exists, exit. Otherwise, create it
 if [[ -f "${DATABASE_PATH}" ]]; then
-    echo "Removing existing SQLite database file..."
-    rm -f "${DATABASE_PATH}"
+    echo "SQLite database file exists and is mounted correctly."
+else
+    echo "SQLite database file doesn't exist or wasn't mounted correctly. Creating it now..."
+    mkdir -p ${DATABASE_DIRECTORY}
+    chown -R "$(id -u)":"$(id -g)" "${DATABASE_DIRECTORY}"
+
+    # SQLite is eccentric in a sense that if you just invoke `sqlite3 <db_file>`, it won't
+    # actually create the file. We are using a hack here to initialize the database with
+    # a test table and then drop it.
+    echo "${ENTRY_QUERY}" | sqlite3 "${DATABASE_PATH}"
+    echo "${DROP_QUERY}" | sqlite3 "${DATABASE_PATH}"
+
+    # Set journal mode to Write-Ahead Logging. This makes it much faster, at the risk of
+    # possibly losing data if the machine crashes suddenly.
+    # https://www.sqlite.org/wal.html
+    echo "PRAGMA journal_mode=WAL;" | sqlite3 "${DATABASE_PATH}"
 fi
-
-# Create the database directory if it doesn't exist
-mkdir -p ${DATABASE_DIRECTORY}
-chown -R "$(id -u)":"$(id -g)" "${DATABASE_DIRECTORY}"
-
-# SQLite is eccentric in a sense that if you just invoke `sqlite3 <db_file>`, it won't
-# actually create the file. We are using a hack here to initialize the database with
-# a test table and then drop it.
-echo "${ENTRY_QUERY}" | sqlite3 "${DATABASE_PATH}"
-echo "${DROP_QUERY}" | sqlite3 "${DATABASE_PATH}"
-
-# Set journal mode to Write-Ahead Logging. This makes it much faster, at the risk of
-# possibly losing data if the machine crashes suddenly.
-# https://www.sqlite.org/wal.html
-echo "PRAGMA journal_mode=WAL;" | sqlite3 "${DATABASE_PATH}"
-
-echo "SQLite database has been created."

--- a/deploy/k3s/edge_deployment/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment/edge_deployment.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: edge-endpoint-service-account
       initContainers:
       - name: database-prep
-        image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:tyler-fix-unconfigured-detector-deployment-bug-1bb99d030-dirty-341a94b766ec6fb
+        image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:tyler-fix-unconfigured-detector-deployment-bug-5142166ef-dirty-e1d92c296fdad43
         imagePullPolicy: Always
         volumeMounts:
         - name: edge-endpoint-persistent-volume

--- a/deploy/k3s/edge_deployment/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment/edge_deployment.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: edge-endpoint-service-account
       initContainers:
       - name: database-prep
-        image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:latest
+        image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:tyler-fix-unconfigured-detector-deployment-bug-1f08c6d66-dirty-bc1d3f8d3b2fe9e
         imagePullPolicy: Always
         env:
         # Flag to indicate whether or not to reset all database tables. Resetting WILL delete

--- a/deploy/k3s/edge_deployment/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment/edge_deployment.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: edge-endpoint-service-account
       initContainers:
       - name: database-prep
-        image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:tyler-fix-unconfigured-detector-deployment-bug-5142166ef-dirty-e1d92c296fdad43
+        image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:latest
         imagePullPolicy: Always
         volumeMounts:
         - name: edge-endpoint-persistent-volume

--- a/deploy/k3s/edge_deployment/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment/edge_deployment.yaml
@@ -40,16 +40,8 @@ spec:
       serviceAccountName: edge-endpoint-service-account
       initContainers:
       - name: database-prep
-        image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:tyler-fix-unconfigured-detector-deployment-bug-1f08c6d66-dirty-bc1d3f8d3b2fe9e
+        image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:tyler-fix-unconfigured-detector-deployment-bug-1bb99d030-dirty-341a94b766ec6fb
         imagePullPolicy: Always
-        env:
-        # Flag to indicate whether or not to reset all database tables. Resetting WILL delete
-        # all existing data in the database, so set this flag to 1 with caution.
-        - name: DB_RESET
-          valueFrom:
-            configMapKeyRef:
-              name: db-reset
-              key: DB_RESET
         volumeMounts:
         - name: edge-endpoint-persistent-volume
           mountPath: /opt/groundlight/edge/sqlite

--- a/test/database_manager/test_database_manager.py
+++ b/test/database_manager/test_database_manager.py
@@ -111,6 +111,24 @@ def test_update_inference_deployment_record(db_manager, database_reset):
             assert bool(result.deployment_created) is True
 
 
+def test_delete_inference_deployment_record(db_manager, database_reset):
+    """Check that we can delete all records in the inference_deployments table."""
+    deployments = [
+        {"detector_id": prefixed_ksuid("det_"), "api_token": prefixed_ksuid("api_"), "deployment_created": False}
+        for _ in range(NUM_TESTING_RECORDS)
+    ]
+
+    for deployment in deployments:
+        db_manager.create_inference_deployment_record(deployment=deployment)
+
+    db_manager.delete_inference_deployment_records()
+
+    # Ensure that all records have been deleted
+    with db_manager.session_maker() as session:
+        count = session.execute(text("SELECT COUNT(*) FROM inference_deployments")).scalar()
+        assert count == 0
+
+
 def test_update_api_token_for_detector(db_manager, database_reset):
     deployment = {
         "detector_id": prefixed_ksuid("det_"),
@@ -146,7 +164,7 @@ def test_get_inference_deployments_raises_sqlalchemy_error(db_manager: DatabaseM
 
     # We will query with invalid parameters and make sure that we get an error
     with pytest.raises(SQLAlchemyError):
-        db_manager.get_inference_deployments(detector_id=deployment["detector_id"], image_query_id="invalid_id")
+        db_manager.get_inference_deployment_records(detector_id=deployment["detector_id"], image_query_id="invalid_id")
 
 
 def test_get_binary_iqe_record(db_manager, database_reset):


### PR DESCRIPTION
New behavior:
1. Send IQ to edge-endpoint for detector not in edge config
2. Spin up an inference server for that detector
3. Works even if edge is restarted

Extant buggy behavior:
1. Send IQ to edge-endpoint for detector not in edge config
2. Spin up an inference server for that detector
3. Restart edge
4. Send IQ to edge-endpoint for detector not in edge config
5. No inference server spins up

This is because we keep track of the state of the k8s deployment in the DB for some reason... And never reset the db from deployed -> not deployed.

Anyways this is a quick fix and also resets the DB upon edge-endpoint start, which is good bc we dont want there to be an expectation that eIQs or anything are persisted forever.