### PR TITLE
Add rate limit to background escalations

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,17 @@ detectors:
   - detector_id: 'det_ijk'
     local_inference_template: "default"
     always_return_edge_prediction: true
+    min_time_between_escalations: 5
 
   - detector_id: 'det_abc'
     local_inference_template: "default"
 ```
 In this example, `det_xyz` will have cloud escalation disabled because `disable_cloud_escalation` is set to `true` and `always_return_edge_prediction` is also `true`. `det_ijk` will have edge-only inference enabled because `always_return_edge_prediction` is set to `true` while `disable_cloud_escalation` is `false`. If neither `always_return_edge_prediction` nor `disable_cloud_escalation` are specified, they default to `false`, so `det_abc` will have both options disabled.
 
-With `always_return_edge_prediction` enabled for a detector, when you make requests to it, you will receive answers from the edge model regardless of the confidence level. However, if `disable_cloud_escalation` is not set to `true`, image queries with confidences below the threshold will be escalated to the cloud and used to train the model. This configuration is useful when you want fast edge answers but still want the model to improve.
+With `always_return_edge_prediction` enabled for a detector, when you make requests to it, you will receive answers from the edge model regardless of the confidence level. However, if `disable_cloud_escalation` is not set to `true`, image queries with confidences below the threshold will be escalated to the cloud and used to train the model. This configuration is useful when you want fast edge answers but still want the model to improve. 
+
+When `always_return_edge_prediction` is set to `true` and `disable_cloud_escalation` is set to `false`, the `min_time_between_escalations` field sets the minimum number of seconds that must pass between image query escalations to the cloud through background escalations. This is to prevent the edge endpoint from sending too many escalation requests in a short period of time to the cloud. The default time between escalations is 2 seconds if this config option is not set. 
+This config option is not valid if `always_return_edge_prediction` is `false` or `disable_cloud_escalation` is `true`.
 
 If `disable_cloud_escalation` is set to `true`, the edge endpoint will not send image queries to the cloud API, and you will only receive answers from the edge model. This option should be used if you don't need the model to improve and only want fast answers from the edge model. Note that no image queries submitted this way will show up in the web app or be used to train the model.
 

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -160,7 +160,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
             if not disable_cloud_escalation and not is_confident_enough:
                 # Only escalate if we haven't escalated on this detector too recently
                 if app_state.edge_inference_manager.escalation_cooldown_complete(detector_id=detector_id):
-                    logger.debug(
+                    logger.info(
                         f"Escalating to cloud due to low confidence: {ml_confidence} < thresh={confidence_threshold}"
                     )
                     background_tasks.add_task(
@@ -173,7 +173,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
                         human_review=human_review,
                     )
                 else:
-                    logger.debug(
+                    logger.info(
                         f"Not escalating to cloud due to rate limit on background cloud escalations: {detector_id=}"
                     )
 

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -156,24 +156,26 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
             )
             app_state.db_manager.create_iqe_record(image_query)
 
-            # escalate after returning edge prediction if enabled and we haven't escalated on this detector too recently
-            if (
-                not disable_cloud_escalation
-                and not is_confident_enough
-                and app_state.edge_inference_manager.escalation_cooldown_complete(detector_id=detector_id)
-            ):
-                logger.debug(
-                    f"Escalating to cloud due to low confidence: {ml_confidence} < thresh={confidence_threshold}"
-                )
-                background_tasks.add_task(
-                    safe_call_sdk,
-                    gl.ask_async,
-                    detector=detector_id,
-                    image=image_bytes,
-                    patience_time=patience_time,
-                    confidence_threshold=confidence_threshold,
-                    human_review=human_review,
-                )
+            # Escalate after returning edge prediction if escalation is enabled and we have low confidence
+            if not disable_cloud_escalation and not is_confident_enough:
+                # Only escalate if we haven't escalated on this detector too recently
+                if app_state.edge_inference_manager.escalation_cooldown_complete(detector_id=detector_id):
+                    logger.debug(
+                        f"Escalating to cloud due to low confidence: {ml_confidence} < thresh={confidence_threshold}"
+                    )
+                    background_tasks.add_task(
+                        safe_call_sdk,
+                        gl.ask_async,
+                        detector=detector_id,
+                        image=image_bytes,
+                        patience_time=patience_time,
+                        confidence_threshold=confidence_threshold,
+                        human_review=human_review,
+                    )
+                else:
+                    logger.debug(
+                        f"Not escalating to cloud due to rate limit on background cloud escalations: {detector_id=}"
+                    )
 
             return image_query
 

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -156,7 +156,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
             )
             app_state.db_manager.create_iqe_record(image_query)
 
-            # escalate after returning edge prediction
+            # escalate after returning edge prediction if enabled and we haven't escalated on this detector too recently
             if (
                 not disable_cloud_escalation
                 and not is_confident_enough

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -160,7 +160,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
             if not disable_cloud_escalation and not is_confident_enough:
                 # Only escalate if we haven't escalated on this detector too recently
                 if app_state.edge_inference_manager.escalation_cooldown_complete(detector_id=detector_id):
-                    logger.info(
+                    logger.debug(
                         f"Escalating to cloud due to low confidence: {ml_confidence} < thresh={confidence_threshold}"
                     )
                     background_tasks.add_task(
@@ -173,7 +173,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
                         human_review=human_review,
                     )
                 else:
-                    logger.info(
+                    logger.debug(
                         f"Not escalating to cloud due to rate limit on background cloud escalations: {detector_id=}"
                     )
 

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -156,7 +156,8 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
             )
             app_state.db_manager.create_iqe_record(image_query)
 
-            if not disable_cloud_escalation and not is_confident_enough:  # escalate after returning edge prediction
+            # escalate after returning edge prediction
+            if not disable_cloud_escalation and not is_confident_enough and app_state.edge_inference_manager.escalation_cooldown_complete(detector_id=detector_id):  
                 logger.debug(
                     f"Escalating to cloud due to low confidence: {ml_confidence} < thresh={confidence_threshold}"
                 )

--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -109,7 +109,7 @@ class AppState:
     def __init__(self):
         self.edge_config = load_edge_config()
         inference_config = get_inference_configs(root_edge_config=self.edge_config)
-        self.edge_inference_manager = EdgeInferenceManager(config=inference_config)
+        self.edge_inference_manager = EdgeInferenceManager(inference_configs=inference_config, edge_config=self.edge_config)
         self.db_manager = DatabaseManager()
         self.is_ready = False
 

--- a/app/core/configs.py
+++ b/app/core/configs.py
@@ -44,8 +44,8 @@ class DetectorConfig(BaseModel):
             "Requires `always_return_edge_prediction=True`."
         ),
     )
-    min_time_between_escalations: float = Field(
-        default=3,
+    min_time_between_escalations: Optional[float] = Field(
+        default=None,
         description=(
             "The minimum time (in seconds) to wait between cloud escalations for a given detector. "
             "Only applies when `always_return_edge_prediction=True` and `disable_cloud_escalation=False`."

--- a/app/core/configs.py
+++ b/app/core/configs.py
@@ -44,12 +44,25 @@ class DetectorConfig(BaseModel):
             "Requires `always_return_edge_prediction=True`."
         ),
     )
+    min_time_between_escalations: float = Field(
+        default=3,
+        description=(
+            "The minimum time (in seconds) to wait between cloud escalations for a given detector. "
+            "Only applies when `always_return_edge_prediction=True` and `disable_cloud_escalation=False`."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_configuration(self) -> Self:
         if self.disable_cloud_escalation and not self.always_return_edge_prediction:
             raise ValueError(
                 "The `disable_cloud_escalation` flag is only valid when `always_return_edge_prediction` is set to True."
+            )
+        if (
+            not self.always_return_edge_prediction or self.disable_cloud_escalation
+        ) and self.min_time_between_escalations is not None:
+            raise ValueError(
+                "The `min_time_between_escalations` field is only valid when `always_return_edge_prediction` is set to True and `disable_cloud_escalation` is set to False."
             )
         return self
 

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -254,6 +254,12 @@ class EdgeInferenceManager:
     def escalation_cooldown_complete(self, detector_id: str, min_time_between_escalations: float = 2) -> bool:
         """
         Check if the time since the last escalation is long enough ago that we should escalate again.
+
+        Args:
+            detector_id: ID of the detector to check
+            min_time_between_escalations: Minimum number of seconds between escalations. Defaults to 2.
+        Returns:
+            True if there hasn't been an escalation on this detector in the last `min_time_between_escalations` seconds, False otherwise
         """
         if self.last_escalation_times[detector_id] is None or time.time() - self.last_escalation_times[detector_id] > min_time_between_escalations:
             self.last_escalation_times[detector_id] = time.time()

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -129,12 +129,9 @@ class EdgeInferenceManager:
         self.speedmon = SpeedMonitor()
 
         # Last time we escalated to cloud for each detector
-        self.last_escalation_times = {detector_id: None for detector_id in edge_config.detectors.keys()}
+        self.last_escalation_times = {detector_id: None for detector_id in edge_config.detectors.keys()} if edge_config else {}
         # Minimum time between escalations for each detector
-        self.min_times_between_escalations = {
-            detector_id: detector_config.min_time_between_escalations
-            for detector_id, detector_config in edge_config.detectors.items()
-        }
+        self.min_times_between_escalations = {detector_id: detector_config.min_time_between_escalations for detector_id, detector_config in edge_config.detectors.items()} if edge_config else {}
 
         if inference_configs:
             self.inference_configs = inference_configs

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -121,8 +121,6 @@ class EdgeInferenceManager:
         self.verbose = verbose
         self.inference_config, self.inference_client_urls = {}, {}
         self.speedmon = SpeedMonitor()
-        # Last time we escalated to cloud for each detector
-        self.last_escalation_times = {detector_id: None for detector_id in self.inference_config.keys()}
 
         if config:
             self.inference_config = config
@@ -131,6 +129,8 @@ class EdgeInferenceManager:
                 for detector_id in self.inference_config.keys()
                 if self.detector_configured_for_local_inference(detector_id)
             }
+            # Last time we escalated to cloud for each detector
+            self.last_escalation_times = {detector_id: None for detector_id in self.inference_config.keys()}
 
     def update_inference_config(self, detector_id: str, api_token: str) -> None:
         """

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -129,9 +129,18 @@ class EdgeInferenceManager:
         self.speedmon = SpeedMonitor()
 
         # Last time we escalated to cloud for each detector
-        self.last_escalation_times = {detector_id: None for detector_id in edge_config.detectors.keys()} if edge_config else {}
+        self.last_escalation_times = (
+            {detector_id: None for detector_id in edge_config.detectors.keys()} if edge_config else {}
+        )
         # Minimum time between escalations for each detector
-        self.min_times_between_escalations = {detector_id: detector_config.min_time_between_escalations for detector_id, detector_config in edge_config.detectors.items()} if edge_config else {}
+        self.min_times_between_escalations = (
+            {
+                detector_id: detector_config.min_time_between_escalations
+                for detector_id, detector_config in edge_config.detectors.items()
+            }
+            if edge_config
+            else {}
+        )
 
         if inference_configs:
             self.inference_configs = inference_configs

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -111,7 +111,12 @@ class EdgeInferenceManager:
     INFERENCE_SERVER_URL = "inference-service:8000"
     MODEL_REPOSITORY = MODEL_REPOSITORY_PATH
 
-    def __init__(self, inference_configs: Dict[str, LocalInferenceConfig] | None, edge_config: RootEdgeConfig, verbose: bool = False) -> None:
+    def __init__(
+        self,
+        inference_configs: Dict[str, LocalInferenceConfig] | None,
+        edge_config: RootEdgeConfig,
+        verbose: bool = False,
+    ) -> None:
         """
         Initializes the edge inference manager.
         Args:
@@ -126,7 +131,10 @@ class EdgeInferenceManager:
         # Last time we escalated to cloud for each detector
         self.last_escalation_times = {detector_id: None for detector_id in edge_config.detectors.keys()}
         # Minimum time between escalations for each detector
-        self.min_times_between_escalations = {detector_id: edge_config.detectors.get(detector_id).min_time_between_escalations for detector_id in edge_config.detectors.keys()}
+        self.min_times_between_escalations = {
+            detector_id: edge_config.detectors.get(detector_id).min_time_between_escalations
+            for detector_id in edge_config.detectors.keys()
+        }
 
         if inference_configs:
             self.inference_configs = inference_configs

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -132,8 +132,8 @@ class EdgeInferenceManager:
         self.last_escalation_times = {detector_id: None for detector_id in edge_config.detectors.keys()}
         # Minimum time between escalations for each detector
         self.min_times_between_escalations = {
-            detector_id: edge_config.detectors.get(detector_id).min_time_between_escalations
-            for detector_id in edge_config.detectors.keys()
+            detector_id: detector_config.min_time_between_escalations
+            for detector_id, detector_config in edge_config.detectors.items()
         }
 
         if inference_configs:

--- a/app/model_updater/update_models.py
+++ b/app/model_updater/update_models.py
@@ -120,7 +120,7 @@ def update_models(
     while True:
         start = time.time()
         logger.info("Starting model update check for existing inference deployments.")
-        for detector_id in edge_inference_manager.inference_config.keys():
+        for detector_id in edge_inference_manager.inference_configs.keys():
             try:
                 logger.debug(f"Checking new models and inference deployments for detector_id: {detector_id}")
                 _check_new_models_and_inference_deployments(
@@ -168,7 +168,7 @@ if __name__ == "__main__":
     refresh_rate = get_refresh_rate(root_edge_config=edge_config)
     inference_config = get_inference_configs(root_edge_config=edge_config)
 
-    edge_inference_manager = EdgeInferenceManager(config=inference_config, verbose=True)
+    edge_inference_manager = EdgeInferenceManager(inference_configs=inference_config, edge_config=edge_config, verbose=True)
     deployment_manager = InferenceDeploymentManager()
 
     # We will delegate creation of database tables to the edge-endpoint container.

--- a/configs/edge-config.yaml
+++ b/configs/edge-config.yaml
@@ -14,3 +14,4 @@ detectors:
       local_inference_template: "default"
       always_return_edge_prediction: false
       disable_cloud_escalation: false
+      min_time_between_escalations: None

--- a/test/core/test_configs.py
+++ b/test/core/test_configs.py
@@ -25,10 +25,55 @@ def test_detector_config_validation():
         disable_cloud_escalation=True,
     )
 
+    DetectorConfig(
+        detector_id="det_xyz",
+        local_inference_template="default",
+        always_return_edge_prediction=True,
+        disable_cloud_escalation=False,
+        min_time_between_escalations=10,
+    )
+
+    DetectorConfig(
+        detector_id="det_xyz",
+        local_inference_template="default",
+        always_return_edge_prediction=True,
+        disable_cloud_escalation=False,
+        min_time_between_escalations=0.5,
+    )
+
+    DetectorConfig(
+        detector_id="det_xyz",
+        local_inference_template="default",
+        always_return_edge_prediction=True,
+        disable_cloud_escalation=True,
+        min_time_between_escalations=None,
+    )
+
+    # disable_cloud_escalation cannot be True if always_return_edge_prediction is False
     with pytest.raises(ValueError):
         DetectorConfig(
             detector_id="det_xyz",
             local_inference_template="default",
             always_return_edge_prediction=False,
             disable_cloud_escalation=True,
+        )
+
+    # min_time_between_escalations cannot be set if always_return_edge_prediction is False
+    with pytest.raises(ValueError):
+        DetectorConfig(
+            detector_id="det_xyz",
+            local_inference_template="default",
+            always_return_edge_prediction=False,
+            disable_cloud_escalation=False,
+            min_time_between_escalations=10,
+        )
+
+    # min_time_between_escalations cannot be set if disable_cloud_escalation is True
+    with pytest.raises(ValueError):
+        DetectorConfig(
+            detector_id="det_xyz",
+            local_inference_template="default",
+            always_return_edge_prediction=True,
+            disable_cloud_escalation=True,
+            min_time_between_escalations=10,
         )

--- a/test/edge_inference/test_model_update.py
+++ b/test/edge_inference/test_model_update.py
@@ -92,7 +92,7 @@ def test_update_model_with_no_new_model_available():
                     "model_binary_id": test_ksuid,
                     "predictor_metadata": test_predictor_metadata,
                 }
-                edge_manager = EdgeInferenceManager(config=None)
+                edge_manager = EdgeInferenceManager(inference_configs=None, edge_config=None)
                 edge_manager.MODEL_REPOSITORY = temp_dir  # type: ignore
                 edge_manager.update_model("test_detector")
                 # We shouldnt be pulling a model from s3 if we know there is nothing new available


### PR DESCRIPTION
This PR adds a rate limit to detectors running background escalations to the cloud. The default time to wait between escalations will be 2 seconds, but we'll allow customers to set that for themselves. If they set too small of a limit (or a limit of 0), they'll still be effectively limited by our usual throttling. 

Unit test coverage of `image_queries.py` is still a little lacking, and that's a larger fix than I think makes sense to do in this PR. I tested out the new option with the demo code. 