### PR TITLE
Fix inference model updates

### DIFF
--- a/app/core/kubernetes_management.py
+++ b/app/core/kubernetes_management.py
@@ -171,8 +171,8 @@ class InferenceDeploymentManager:
 
         # Set the correct model name for this inference deployment
         for env_var in deployment.spec.template.spec.containers[0].env:
-            if env_var["name"] == "MODEL_NAME":
-                env_var["value"] = detector_id
+            if env_var.name == "MODEL_NAME":
+                env_var.value = detector_id
                 break
 
         logger.info(f"Patching an existing inference deployment: {deployment_name}")


### PR DESCRIPTION
Fixes an error that arose from incorrect access of the env var attributes. Previously, the inference-model-updater would fetch a new binary but would not spawn an updated inference pod because of this error, and you would have to run cluster_setup again to use the new binary. Now, the updated model binary will actually be used once fetched.

Error that would happen:
`TypeError: 'V1EnvVar' object is not subscriptable`