### PR TITLE
Dealing with kernel issue on raspberry pi with k3s

### DIFF
--- a/deploy/bin/check_cgroup.sh
+++ b/deploy/bin/check_cgroup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Function to check if memory cgroup is mounted
+check_memory_cgroup_mounted() {
+    if mount | grep -q "cgroup/memory"; then
+        echo "Memory cgroup is mounted."
+        return 0
+    else
+        echo "Memory cgroup is NOT mounted."
+        return 1
+    fi
+}
+
+# Function to check kernel cmdline parameters for cgroup settings
+check_cmdline_params() {
+    CMDLINE=$(cat /proc/cmdline)
+    if echo "$CMDLINE" | grep -q "cgroup_memory=1" && echo "$CMDLINE" | grep -q "cgroup_enable=memory"; then
+        echo "Required cgroup parameters are present in /proc/cmdline."
+        return 0
+    else
+        echo "Required cgroup parameters are MISSING from /proc/cmdline."
+        return 1
+    fi
+}
+
+# Run both checks and determine overall status
+check_memory_cgroup_mounted
+MOUNT_STATUS=$?
+
+check_cmdline_params
+PARAM_STATUS=$?
+
+if [ $MOUNT_STATUS -eq 0 ] && [ $PARAM_STATUS -eq 0 ]; then
+    echo "Memory cgroup is properly enabled."
+    exit 0
+else
+    echo "Memory cgroup is NOT properly enabled."
+    exit 1
+fi
+

--- a/deploy/bin/install-k3s.sh
+++ b/deploy/bin/install-k3s.sh
@@ -7,6 +7,20 @@ K="k3s kubectl"
 # Update system
 sudo apt update && sudo apt upgrade -y
 
+# Check cgroup setup
+./check_cgroup.sh
+CGROUP_STATUS=$?    
+
+if [ $CGROUP_STATUS -eq 1 ]; then
+    cat << EOF
+Cgroup setup is NOT correct.  k3s will probably not work on this system.
+To fix, add the following to the kernel command line in your bootloader configuration:
+    cgroup_memory=1 cgroup_enable=memory
+You can do this with grub on most systems, 
+or on Raspberry Pi by editing /boot/cmdline.txt or /boot/firmware/cmdline.txt.
+EOF
+    exit 1
+fi
 
 # Install k3s
 echo "Installing k3s..."


### PR DESCRIPTION
Many/most raspberry pi OS's don't have cgroups properly enabled in the kernel, and so k3s will fail to run.  This change detects the problem and gives strong hints about how to fix it.