### PR TITLE
Setup edge deployments to 'preflight' and 'live' balena environments

### DIFF
--- a/.github/workflows/deploy-balena.yaml
+++ b/.github/workflows/deploy-balena.yaml
@@ -42,4 +42,4 @@ jobs:
       - name: Login and Push to Fleet 
         run: |
           balena login --token ${{ secrets.BALENA_AUTH_TOKEN }}
-          balena push edge-endpoint-${{ inputs.FLEET_NAME }}
+          balena push edge-${{ inputs.FLEET_NAME }}

--- a/.github/workflows/deploy-balena.yaml
+++ b/.github/workflows/deploy-balena.yaml
@@ -1,0 +1,48 @@
+name: Setup and Deploy to Balena Fleet
+
+on:
+  workflow_call:
+    inputs:
+      environmentName:
+        required: true
+        type: string
+    secrets:
+      BALENA_AUTH_TOKEN:
+        required: true
+      FLEET_NAME: 
+        required: true
+      
+
+jobs:
+  setup-and-deploy:
+    runs-on: ubuntu-22.04
+    environment: ${{ inputs.environmentName }}
+    outputs:
+      cli-path: ${{ steps.setup_cli.outputs.cli-path }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Balena CLI
+        id: setup_cli
+        run: |
+          set -ex 
+          sudo apt-get update && sudo apt-get -y install curl unzip
+          curl -L -o balena-cli.zip "https://github.com/balena-io/balena-cli/releases/download/v18.0.0/balena-cli-v18.0.0-linux-x64-standalone.zip"
+          unzip balena-cli.zip -d $HOME/balena-cli
+          BALENA_CLI_PATH=$(find $HOME/balena-cli -name 'balena' -type f -executable | head -n 1)
+          if [[ ! -z "$BALENA_CLI_PATH" ]]; then
+            chmod +x "$BALENA_CLI_PATH"
+            echo "$(dirname $BALENA_CLI_PATH)" >> $GITHUB_PATH
+            echo "::set-output name=cli-path::$(dirname $BALENA_CLI_PATH)"
+          else
+            echo "Balena CLI executable not found"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Check Balena CLI version
+        run: balena --version
+      - name: Login and Push to Fleet 
+        run: |
+          balena login --token ${{ secrets.BALENA_AUTH_TOKEN }}
+          balena push ${{ secrets.FLEET_NAME }}

--- a/.github/workflows/deploy-balena.yaml
+++ b/.github/workflows/deploy-balena.yaml
@@ -3,20 +3,17 @@ name: Setup and Deploy to Balena Fleet
 on:
   workflow_call:
     inputs:
-      environmentName:
+      FLEET_NAME:
         required: true
         type: string
     secrets:
       BALENA_AUTH_TOKEN:
         required: true
-      FLEET_NAME: 
-        required: true
-      
 
 jobs:
   setup-and-deploy:
     runs-on: ubuntu-22.04
-    environment: ${{ inputs.environmentName }}
+    environment: ${{ inputs.FLEET_NAME }}
     outputs:
       cli-path: ${{ steps.setup_cli.outputs.cli-path }}
     steps:
@@ -45,4 +42,4 @@ jobs:
       - name: Login and Push to Fleet 
         run: |
           balena login --token ${{ secrets.BALENA_AUTH_TOKEN }}
-          balena push ${{ secrets.FLEET_NAME }}
+          balena push edge-endpoint-${{ inputs.FLEET_NAME }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -251,7 +251,10 @@ jobs:
           kubectl describe pod edge-endpoint
   
   deploy-edge-preflight-balena:
-    if: github.event_name == 'push'
+    needs: 
+      - test-general-edge-endpoint
+      - test-in-k3s
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/deploy-balena.yaml
     with:
       FLEET_NAME: preflight
@@ -262,7 +265,6 @@ jobs:
   deploy-edge-live-balena:
     needs: 
       - deploy-edge-preflight-balena
-    if: github.event_name == 'push'
     uses: ./.github/workflows/deploy-balena.yaml
     with:
       FLEET_NAME: live

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -257,7 +257,6 @@ jobs:
       FLEET_NAME: preflight
     secrets:
       BALENA_AUTH_TOKEN: ${{ secrets.BALENA_AUTH_TOKEN }}
-      FLEET_NAME: ${{ secrets.FLEET_NAME }}
 
 
   deploy-edge-live-balena:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -256,7 +256,7 @@ jobs:
       - test-in-k3s
     uses: ./.github/workflows/deploy-balena.yaml
     with:
-      environmentName: preflight
+      FLEET_NAME: preflight
     secrets:
       BALENA_AUTH_TOKEN: ${{ secrets.BALENA_AUTH_TOKEN }}
       FLEET_NAME: ${{ secrets.FLEET_NAME }}
@@ -268,7 +268,6 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/deploy-balena.yaml
     with:
-      environmentName: live
+      FLEET_NAME: live
     secrets:
       BALENA_AUTH_TOKEN: ${{ secrets.BALENA_AUTH_TOKEN }}
-      FLEET_NAME: ${{ secrets.FLEET_NAME }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -251,7 +251,7 @@ jobs:
           kubectl describe pod edge-endpoint
   
   deploy-edge-preflight-balena:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     uses: ./.github/workflows/deploy-balena.yaml
     with:
       FLEET_NAME: preflight

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -251,9 +251,7 @@ jobs:
           kubectl describe pod edge-endpoint
   
   deploy-edge-preflight-balena:
-    needs: 
-      - test-general-edge-endpoint
-      - test-in-k3s
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/deploy-balena.yaml
     with:
       FLEET_NAME: preflight

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -262,7 +262,7 @@ jobs:
   deploy-edge-live-balena:
     needs: 
       - deploy-edge-preflight-balena
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push'
     uses: ./.github/workflows/deploy-balena.yaml
     with:
       FLEET_NAME: live

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -249,3 +249,26 @@ jobs:
           set -ex
           kubectl rollout status deployment edge-endpoint --timeout=5m
           kubectl describe pod edge-endpoint
+  
+  deploy-edge-preflight-balena:
+    needs: 
+      - test-general-edge-endpoint
+      - test-in-k3s
+    uses: ./.github/workflows/deploy-balena.yaml
+    with:
+      environmentName: preflight
+    secrets:
+      BALENA_AUTH_TOKEN: ${{ secrets.BALENA_AUTH_TOKEN }}
+      FLEET_NAME: ${{ secrets.FLEET_NAME }}
+
+
+  deploy-edge-live-balena:
+    needs: 
+      - deploy-edge-preflight-balena
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/deploy-balena.yaml
+    with:
+      environmentName: live
+    secrets:
+      BALENA_AUTH_TOKEN: ${{ secrets.BALENA_AUTH_TOKEN }}
+      FLEET_NAME: ${{ secrets.FLEET_NAME }}


### PR DESCRIPTION
I setup two fleets in balena called 'preflight' (we can use this one to run integration tests, control releases etc) and 'live' (for customer and other important edge devices). These are managed through github environments. Like in zuuul, we need an explicit approval to deploy the live fleet. Talking through with Tyler, there are a few key next steps here:
- Setting up integration tests through the preflight fleet.
- Improve unit tests
- Get live fleet into a state where we feel comfortable that it works without much manual intervention for our customers. This is where I'm most unclear about next steps.