### PR TITLE
Include metadata identifying edge results

### DIFF
--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -55,7 +55,7 @@ def create_iq(  # noqa: PLR0913
     result_type, result = _mode_to_result_and_type(mode, mode_configuration, confidence, result_value)
 
     return ImageQuery(
-        metadata=None,
+        metadata={"is_from_edge": True},
         id=prefixed_ksuid(prefix="iq_"),
         type=ImageQueryTypeEnum.image_query,
         created_at=datetime.now(timezone.utc),

--- a/test/api/test_utils.py
+++ b/test/api/test_utils.py
@@ -39,6 +39,8 @@ class TestCreateIQ:
         assert isinstance(iq.result, BinaryClassificationResult)
         assert iq.result.source == Source.ALGORITHM
         assert iq.result.label == Label.YES
+        assert "is_from_edge" in iq.metadata
+        assert iq.metadata["is_from_edge"]
 
     def test_create_count_iq(self):
         """Test creating a basic count IQ."""
@@ -59,6 +61,8 @@ class TestCreateIQ:
         assert iq.result.source == Source.ALGORITHM
         assert iq.result.count == count_value
         assert not iq.result.greater_than_max
+        assert "is_from_edge" in iq.metadata
+        assert iq.metadata["is_from_edge"]
 
     def test_create_count_iq_greater_than_max(self):
         """Test creating a count IQ with count greater than the max count."""


### PR DESCRIPTION
When an IQ is created and returned from the edge, it will now have `is_from_edge: True` in the metadata so it can be identified as an edge answer.