### PR TITLE
Fix persistent volume conflict check

### DIFF
--- a/deploy/bin/setup-ee.sh
+++ b/deploy/bin/setup-ee.sh
@@ -146,7 +146,7 @@ $K get service -o custom-columns=":metadata.name" --no-headers=true | \
 
 # Check if DEPLOY_LOCAL_VERSION is set. If so, use a local volume instead of an EFS volume
 if [[ "${DEPLOY_LOCAL_VERSION}" == "1" ]]; then
-    if ! check_pv_conflict "$PERSISTENT_VOLUME_NAME" "local-sc"; then
+    if ! check_pv_conflict "$PERSISTENT_VOLUME_NAME" "null"; then
         fail "PersistentVolume $PERSISTENT_VOLUME_NAME conflicts with the existing resource."
     fi
 

--- a/test/validate_setup_ee.sh
+++ b/test/validate_setup_ee.sh
@@ -18,5 +18,5 @@ echo "Edge-endpoint pods have successfully rolled out in namespace $DEPLOYMENT_N
 echo "Deleting namespace $DEPLOYMENT_NAMESPACE..."
 kubectl delete namespace $DEPLOYMENT_NAMESPACE
 
-echo "Deleting persistant volume..."
+echo "Deleting persistent volume..."
 kubectl delete pv edge-endpoint-pv


### PR DESCRIPTION
Now that we don't assign the local persistent volume a storage class, the conflict check was failing every time I re-ran `setup-ee.sh` after the first time because it was still expecting the PV to have `local-sc` storage class.

Also fixes a small typo I noticed.