### PR TITLE
Fix handling of human_review=ALWAYS

### DIFF
--- a/test/api/test_image_queries.py
+++ b/test/api/test_image_queries.py
@@ -187,6 +187,8 @@ def test_post_image_query_with_async_request(test_client: TestClient, detector: 
         assert "id" in response_data, "Response should contain an 'id' field"
 
 
+# TODO: This test doesn't seem to actually test this behavior, since it was passing when it should have failed.
+# It should get removed once this behavior is tested in the live environment.
 def test_post_image_query_with_human_review(test_client: TestClient, detector: Detector):
     """Test submitting an image query with human review set to ALWAYS."""
     image_bytes = pil_image_to_bytes(img=Image.open("test/assets/dog.jpeg"))


### PR DESCRIPTION
When motion detection was removed, the check for `human_review=ALWAYS` was accidentally removed, meaning currently even when `human_review=ALWAYS` the edge answer will be returned if it's confident enough. This adds the check back in to make sure we handle that parameter correctly. 

There's a test for this behavior [here](https://github.com/groundlight/edge-endpoint/blob/a33b0ae46da67062d2ba926cc51525f6e39ab5a8/test/api/test_image_queries.py#L190) which doesn't seem to be working correctly since it's been passing this whole time. After a bit of poking around I couldn't figure out how to fix the current test, so I think it might make sense to just leave it until my new live tests are added (which are actually how I found this bug!). 