### PR TITLE
Create CODEOWNERS file to restrict who can approve PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file defines the github usernames (or group names) who are
+# allowed to approve PR's for the code.
+
+* @groundlight/employees


### PR DESCRIPTION
This file will let us turn on the branch protection rule requiring approval from specific people/teams