### PR TITLE
Adding workflow to validate workflow yamls

### DIFF
--- a/.github/.yamllint.yaml
+++ b/.github/.yamllint.yaml
@@ -1,0 +1,14 @@
+extends: default
+
+rules:
+  document-start: disable  # GH doesn't care.
+  truthy: disable  # Otherwise every `on:` triggers a warning.  Stupid.
+  indentation:
+    spaces: consistent
+    level: error
+  line-length:
+    max: 150
+    level: warning
+  comments: disable
+  trailing-spaces: disable
+  empty-lines: disable

--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -11,9 +11,9 @@ jobs:
     if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      name: checkout code
-    - uses: uesteibar/reviewer-lottery@v3
-      name: randomly assign reviewer
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+        name: checkout code
+      - uses: uesteibar/reviewer-lottery@v3
+        name: randomly assign reviewer
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-workflow-files.yaml
+++ b/.github/workflows/validate-workflow-files.yaml
@@ -1,0 +1,51 @@
+name: Workflow YAML check
+# Note that without this, a single minor mistake in a workflow YAML
+# will cause github to SILENTLY FAIL.  It will:
+# - Not run any part of the workflow
+# - Not even report that there was an error in the file
+# This could cause a key set of checks to not run, and thus an important
+# error to slip by unnoticed.
+
+# TODO: It would be nice to validate the semantics of the workflow files
+# not just their basic syntax, but this is a good start.
+# e.g. if a job has a "needs:" field but nothing listed under it,
+# that will pass linting, but fail at GH.  I believe there's a GH API
+# we can post to that will validate the workflow files.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/*.yaml'
+      - '.github/.yamllint.yaml'
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/*.yaml'
+      - '.github/.yamllint.yaml'
+
+jobs:
+  check-workflow-files:
+    runs-on: ubuntu-22.04
+
+    defaults:
+      run:
+        working-directory: .github/workflows
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install yamllint
+        run: |
+          python -m pip install --upgrade pip
+          pip install yamllint
+
+      - name: Run yamllint
+        run: yamllint -c ../.yamllint.yaml *.yaml


### PR DESCRIPTION
Previously if you had a syntax error in your github workflow yaml, it would fail (almost) silently.  This adds some obvious/visible failure/check if you have a syntax error in your github workflow yamls by running a not-strict linter on them.
