### PR TITLE
Cache detector metadata indefinitely

### DIFF
--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -115,6 +115,12 @@ def refresh_detector_metadata_if_needed(detector_id: str, gl: Groundlight) -> No
                 get_detector_metadata(detector_id=detector_id, gl=gl)
                 metadata_cache.delete_suspended_value(detector_id)
                 logger.info(f"Detector metadata for {detector_id=} refreshed successfully.")
+            except KeyError:
+                # This shouldn't happen, but if we fail to delete the suspended value we don't want to try to restore it
+                logger.warning(
+                    f"After fetching new metadata, did not successfully delete suspended value for {detector_id=}. "
+                    "This is unexpected."
+                )
             except Exception as e:
                 logger.error(
                     f"Failed to refresh detector metadata for {detector_id=}: {e}. Restoring stale cached metadata."

--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 from functools import lru_cache
 
 import cachetools
@@ -12,13 +13,12 @@ from .configs import EdgeInferenceConfig, RootEdgeConfig
 from .database import DatabaseManager
 from .edge_inference import EdgeInferenceManager
 from .file_paths import DEFAULT_EDGE_CONFIG_PATH
-from .utils import TimestampedTTLCache, safe_call_sdk
+from .utils import TimestampedCache, safe_call_sdk
 
 logger = logging.getLogger(__name__)
 
 MAX_SDK_INSTANCES_CACHE_SIZE = 1000
-MAX_DETECTOR_IDS_TTL_CACHE_SIZE = 1000
-TTL_TIME_SEC = 60 * 10  # 10 minutes
+MAX_DETECTOR_IDS_CACHE_SIZE = 1000
 STALE_METADATA_THRESHOLD_SEC = 30  # 30 seconds
 
 
@@ -99,10 +99,10 @@ def get_groundlight_sdk_instance(request: Request):
 
 def refresh_detector_metadata_if_needed(detector_id: str, gl: Groundlight) -> None:
     """Check if detector metadata needs refreshing based on age of cached value and refresh it if it's too old."""
-    metadata_cache: TimestampedTTLCache = get_detector_metadata.cache
+    metadata_cache: TimestampedCache = get_detector_metadata.cache
     cached_value_timestamp = metadata_cache.get_timestamp(detector_id)
     if cached_value_timestamp is not None:
-        cached_value_age = metadata_cache.timer() - cached_value_timestamp
+        cached_value_age = time.monotonic() - cached_value_timestamp
         if cached_value_age > STALE_METADATA_THRESHOLD_SEC:
             logger.info(f"Detector metadata for {detector_id=} is stale. Refreshing...")
             metadata_cache.pop(detector_id, None)
@@ -111,7 +111,7 @@ def refresh_detector_metadata_if_needed(detector_id: str, gl: Groundlight) -> No
 
 
 @cachetools.cached(
-    cache=TimestampedTTLCache(maxsize=MAX_DETECTOR_IDS_TTL_CACHE_SIZE, ttl=TTL_TIME_SEC),
+    cache=TimestampedCache(maxsize=MAX_DETECTOR_IDS_CACHE_SIZE),
     key=lambda detector_id, gl: detector_id,
 )
 def get_detector_metadata(detector_id: str, gl: Groundlight) -> Detector:

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timezone
 from io import BytesIO
 from typing import Any, Callable
@@ -175,20 +176,20 @@ def pil_image_to_bytes(img: Image.Image, format: str = "JPEG") -> bytes:
         return buffer.getvalue()
 
 
-class TimestampedTTLCache(cachetools.TTLCache):
-    """TTLCache subclass that tracks when items were added to the cache."""
+class TimestampedCache(cachetools.Cache):
+    """Cache subclass that tracks when items were added to the cache."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.timestamps = {}  # Store timestamps for each key
 
-    def __setitem__(self, key, value, cache_setitem=cachetools.Cache.__setitem__):
+    def __setitem__(self, key, value):
         # Track the current time when setting an item
-        self.timestamps[key] = self.timer()
-        super().__setitem__(key, value, cache_setitem)
+        self.timestamps[key] = time.monotonic()
+        super().__setitem__(key, value)
 
-    def __delitem__(self, key, cache_delitem=cachetools.Cache.__delitem__):
-        super().__delitem__(key, cache_delitem)
+    def __delitem__(self, key):
+        super().__delitem__(key)
         self.timestamps.pop(key, None)
 
     def get_timestamp(self, key) -> float | None:

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -200,8 +200,8 @@ class TimestampedCache(cachetools.Cache):
         self.timestamps.pop(key, None)
 
     def get_timestamp(self, key) -> float | None:
-        """Get the timestamp of when an item was added to the cache."""
-        return self.timestamps.get(key)
+        """Get the timestamp of when an item was added to the cache. Returns None if the key is not in the cache."""
+        return self.timestamps.get(key, None)
 
     def suspend_cached_value(self, key) -> bool:
         """

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -203,7 +203,7 @@ class TimestampedCache(cachetools.Cache):
     def suspend_cached_value(self, key) -> bool:
         timestamp = self.timestamps.get(key, None)
         item = self.pop(key, None)
-        if item and timestamp:
+        if item is not None and timestamp is not None:
             self.suspended_values[key] = item
             self.suspended_timestamps[key] = timestamp
             return True
@@ -212,7 +212,7 @@ class TimestampedCache(cachetools.Cache):
     def restore_suspended_value(self, key) -> bool:
         item = self.suspended_values.pop(key, None)
         timestamp = self.suspended_timestamps.pop(key, None)
-        if item and timestamp:
+        if item is not None and timestamp is not None:
             self.__setitem__(key, item, timestamp=timestamp)
             return True
         return False

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -223,6 +223,7 @@ class TimestampedCache(cachetools.Cache):
     def restore_suspended_value(self, key: Any) -> bool:
         """
         Restore a suspended value to the cache.
+        If the key is already in the cache, the existing value will be overwritten.
 
         Returns True if the value was successfully restored.
         Raises KeyError if the key is not in the suspended values.

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from datetime import datetime, timezone
 from io import BytesIO
@@ -22,6 +23,8 @@ from PIL import Image
 from pydantic import BaseModel, ValidationError
 
 from app.core import constants
+
+logger = logging.getLogger(__name__)
 
 
 def create_iq(  # noqa: PLR0913
@@ -222,11 +225,11 @@ class TimestampedCache(cachetools.Cache):
         Returns True if the value was successfully restored.
         Raises KeyError if the key is not in the suspended values.
         """
-        # TODO what should the behavior be if the key is already in the cache?
-
         item = self.suspended_values.pop(key, None)
         timestamp = self.suspended_timestamps.pop(key, None)
         if item is not None and timestamp is not None:
+            if key in self:
+                logger.warning(f"Key {key} already in cache, overwriting with suspended value")
             self.__setitem__(key, item, timestamp=timestamp)
             return True
         raise KeyError(f"Key {key} not found in suspended values")

--- a/test/core/test_metadata_cache.py
+++ b/test/core/test_metadata_cache.py
@@ -137,7 +137,6 @@ def test_timestamped_cache_restore_overwrites_existing():
 
     cache["key3"] = "value3_updated"
     cache.restore_suspended_value("key3")
-    # TODO is this the desired behavior?
     assert cache.get("key3", None) == "value3"  # Restored value overwrites the updated value
 
 

--- a/test/core/test_metadata_cache.py
+++ b/test/core/test_metadata_cache.py
@@ -46,6 +46,8 @@ class MockTimer:
 def test_timestamped_cache_basic():
     """Test basic functionality of the TimestampedCache class."""
     cache = TimestampedCache(maxsize=100)
+
+    # Can set and get a value with its timestamp
     cache["key1"] = "value1"
     assert cache["key1"] == "value1"
     key1_timestamp = cache.get_timestamp("key1")
@@ -56,14 +58,19 @@ def test_timestamped_cache_basic():
     key2_timestamp = cache.get_timestamp("key2")
     assert key2_timestamp is not None
 
+    # Timestamp ordering is correct
     assert key1_timestamp < key2_timestamp
 
+    # Updating a value updates the timestamp
     cache["key1"] = "value1_updated"
     assert cache["key1"] == "value1_updated"
-    assert cache.get_timestamp("key1") is not None
     key1_timestamp_updated = cache.get_timestamp("key1")
     assert key1_timestamp_updated is not None
     assert key1_timestamp_updated > key1_timestamp
+
+    # Deleting an entry removes the timestamp and get_timestamp for the removed key returns None
+    cache.pop("key1")
+    assert cache.get_timestamp("key1") is None
 
 
 def test_timestamped_cache_suspended_values():

--- a/test/core/test_metadata_cache.py
+++ b/test/core/test_metadata_cache.py
@@ -89,6 +89,15 @@ def test_timestamped_cache_suspended_values():
     with pytest.raises(KeyError):
         cache.restore_suspended_value("key2")  # Can't restore a deleted suspended value
 
+    # Restoring a suspended value overrides the existing value in the cache
+    # TODO is this the desired behavior?
+    cache["key3"] = "value3"
+    cache.suspend_cached_value("key3")
+    assert cache.get("key3", None) is None
+    cache["key3"] = "value3_updated"
+    cache.restore_suspended_value("key3")
+    assert cache.get("key3", None) == "value3"
+
     with pytest.raises(KeyError):
         cache.suspend_cached_value("not_in_cache")  # Can't suspend a value that's not in the cache
     with pytest.raises(KeyError):

--- a/test/core/test_metadata_cache.py
+++ b/test/core/test_metadata_cache.py
@@ -5,12 +5,12 @@ from app.core.app_state import (
     get_detector_metadata,
     refresh_detector_metadata_if_needed,
 )
-from app.core.utils import TimestampedTTLCache
+from app.core.utils import TimestampedCache
 
 
 class MockTimer:
     """
-    Mock timer for testing the TimestampedTTLCache class.
+    Mock timer for testing the TimestampedCache class.
     Modified from cachetools _TimedCache._Timer class. Must implement these methods to be compatible with the cache.
     """
 
@@ -42,8 +42,8 @@ class MockTimer:
 
 
 def test_timestamped_ttl_cache():
-    """Test basic functionality of the TimestampedTTLCache class."""
-    cache = TimestampedTTLCache(maxsize=100, ttl=600)
+    """Test basic functionality of the TimestampedCache class."""
+    cache = TimestampedCache(maxsize=100)
     cache["key1"] = "value1"
     assert cache["key1"] == "value1"
     key1_timestamp = cache.get_timestamp("key1")
@@ -70,7 +70,7 @@ def test_refresh_detector_metadata_if_needed():
     mock_timer = MockTimer()
 
     with (
-        patch("app.core.utils.TimestampedTTLCache.timer", new=mock_timer),  # Enable control over the cache's timer
+        patch("app.core.utils.time.monotonic", new=mock_timer),  # Enable control over the cache's timer
         patch("app.core.app_state.safe_call_sdk", return_value=MagicMock()) as mock_sdk_call,
     ):
         # First call to populate cache


### PR DESCRIPTION
Previously, the detector metadata cache would expire after 10 minutes. Additionally, we would attempt to refresh it every 30 seconds, but if the SDK call to refresh it failed the cached value would still be cleared. 

This PR does two things:
1) Makes the detector metadata cache have no time limit so that a cached value will stay indefinitely, unless manually removed (or unless `maxsize=1000` detector IDs get stored in the cache, which seems unlikely)
2) Makes the `refresh_detector_metadata_if_needed` function _not_ clear the cached value if it fails to fetch a new value (e.g., due to no internet connection)

It accomplishes these by removing the TTL aspect of the cache and augmenting it with the ability to "suspend" and "restore" a value from the cache. 

Adds lots of tests to verify both the specific behavior of the cache as well as the overall refreshing behavior.