### PR TITLE
Updating g4-e2e test to use Helm

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -388,7 +388,7 @@ jobs:
           uv run pulumi stack init ${STACK_NAME}
           uv run pulumi config
 
-      - name: Pick which commit we will test
+      - name: Configure pulumi
         run: |
           # We want to test the exact code that GitHub is running right now
           # For PR runs, this is the merge commit that GitHub creates
@@ -396,9 +396,11 @@ jobs:
           # Either way, GITHUB_SHA gives us exactly what we need.
           # This is a proper commit in the repo, you just have to fetch it deliberately.
           # It doesn't show up with a normal `git clone`
-
           COMMIT_TO_TEST=${GITHUB_SHA}
           uv run pulumi config set ee-cicd:targetCommit ${COMMIT_TO_TEST}
+
+          # Inject the API token into the pulumi stack
+          uv run pulumi config set ee-cicd:groundlightApiToken ${GROUNDLIGHT_API_TOKEN}
 
       - name: Create the EEUT instance
         run: |
@@ -434,6 +436,7 @@ jobs:
         run: |
           EEUT_IP=$(uv run pulumi stack output eeut_private_ip)
           echo "If the tests failed, the EEUT (edge endpoint under test) is still running."
+          echo "The sweeper will remove it in an hour or so."
           echo "You can connect to it via ssh using the following command:"
           echo "ssh ubuntu@${EEUT_IP}"
           echo "(Assuming you have the private key and are coming from the right subnet.)"

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -400,7 +400,7 @@ jobs:
           uv run pulumi config set ee-cicd:targetCommit ${COMMIT_TO_TEST}
 
           # Inject the API token into the pulumi stack
-          uv run pulumi config set ee-cicd:groundlightApiToken ${GROUNDLIGHT_API_TOKEN}
+          uv run pulumi config set ee-cicd:groundlightApiToken ${GROUNDLIGHT_API_TOKEN} --secret
 
       - name: Create the EEUT instance
         run: |

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -436,14 +436,9 @@ jobs:
         run: |
           EEUT_IP=$(uv run pulumi stack output eeut_private_ip)
           echo "If the tests failed, the EEUT (edge endpoint under test) is still running."
-          echo "The sweeper will remove it in an hour or so."
-          echo "You can connect to it via ssh using the following command:"
-          echo "ssh ubuntu@${EEUT_IP}"
-          echo "(Assuming you have the private key and are coming from the right subnet.)"
-          echo ""
-          echo "If the machine was put to sleep and you want it back, run:"
-          echo "wake-ec2 eeut-${STACK_NAME}"
-          echo "In the GL_Public account."
+          echo "To connect to it, see the Debugging EEUT runbook.  You'll want to know:"
+          echo "export EEUT_IP=${EEUT_IP}"
+          echo "export EEUT_STACK_NAME=${STACK_NAME}"
 
   build-push-edge-endpoint-multiplatform:
     if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -390,24 +390,14 @@ jobs:
 
       - name: Pick which commit we will test
         run: |
-          echo "This is a bit subtle."
-          echo "We can't just test on 'main' for fairly obvious reasons - we"
-          echo "want to test the code in this PR's branch. The current commit"
-          echo "right here is ${GITHUB_SHA}, which is likely a merge commit."
-          echo "Merge commits are challenging. They are what would happen if"
-          echo "this PR were to be merged into its base branch. But they are"
-          echo "ephemeral things and not available in the public repo. So the"
-          echo "EEUT can't just check them out. Making them available to the"
-          echo "EEUT would require pushing them and polluting the repo. So,"
-          echo "for now, we are going to use the PR's head ref"
-          echo "${{ github.event.pull_request.head.ref }}, which is the commit"
-          echo "that was used to create the PR. Recognizing that this doesn't"
-          echo "reflect what will happen after merge. But it's simpler."
+          # We want to test the exact code that GitHub is running right now
+          # For PR runs, this is the merge commit that GitHub creates
+          # For main branch runs, this is the latest commit on main
+          # Either way, GITHUB_SHA gives us exactly what we need.
+          # This is a proper commit in the repo, you just have to fetch it deliberately.
+          # It doesn't show up with a normal `git clone`
 
-          # TODO: test on the merge commit by pushing it to the repo with a temporary
-          # branch, and then clean up the branch later.
-
-          COMMIT_TO_TEST=${{ github.event.pull_request.head.ref }}
+          COMMIT_TO_TEST=${GITHUB_SHA}
           uv run pulumi config set ee-cicd:targetCommit ${COMMIT_TO_TEST}
 
       - name: Create the EEUT instance

--- a/cicd/bin/install-on-ubuntu.sh
+++ b/cicd/bin/install-on-ubuntu.sh
@@ -68,7 +68,9 @@ if [ -n "$SPECIFIC_COMMIT" ]; then
     # because that would be substituted too!
     if [ "${SPECIFIC_COMMIT:0:11}" != "__EE_COMMIT" ]; then
         echo "Checking out commit ${SPECIFIC_COMMIT}"
-        git checkout ${SPECIFIC_COMMIT}
+        # This might be a merge commit, so we need to fetch it deliberately.
+        git fetch origin $SPECIFIC_COMMIT
+        git checkout $SPECIFIC_COMMIT
     else
         echo "It appears the commit hash was not substituted.  Staying on main."
     fi

--- a/cicd/bin/install-on-ubuntu.sh
+++ b/cicd/bin/install-on-ubuntu.sh
@@ -88,6 +88,8 @@ echo "alias k='kubectl'" >> /home/${TARGET_USER}/.bashrc
 echo "source <(kubectl completion bash)" >> /home/${TARGET_USER}/.bashrc
 echo "complete -F __start_kubectl k" >> /home/${TARGET_USER}/.bashrc
 echo "set -o vi" >> /home/${TARGET_USER}/.bashrc
+echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /home/${TARGET_USER}/.bashrc
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 # This should get substituted by the launching script
 export GROUNDLIGHT_API_TOKEN="__GROUNDLIGHTAPITOKEN__"

--- a/cicd/pulumi/__main__.py
+++ b/cicd/pulumi/__main__.py
@@ -53,10 +53,9 @@ def load_user_data_script() -> str:
     user_data_script = user_data_script.replace("__EE_COMMIT_HASH__", target_commit)
     
     # Substitute the API token into the user data script.
-    api_token_object = config.require_secret("groundlightApiToken")
-    api_token_value = api_token_object.apply(lambda v: v)
-    user_data_script = pulumi.Output.all(api_token_value).apply(
-        lambda values: user_data_script.replace("__GROUNDLIGHTAPITOKEN__", values[0])
+    api_token = config.require_secret("groundlightApiToken")
+    user_data_script = api_token.apply(
+        lambda token: user_data_script.replace("__GROUNDLIGHTAPITOKEN__", token)
     )
 
     return user_data_script

--- a/cicd/pulumi/__main__.py
+++ b/cicd/pulumi/__main__.py
@@ -48,17 +48,17 @@ def load_user_data_script() -> str:
     """Loads and customizes the user data script for the instance, which is used to install 
     everything on the instance."""
     with open('../bin/install-on-ubuntu.sh', 'r') as file:
-        user_data_script = file.read()
+        user_data_script0 = file.read()
     target_commit = get_target_commit()
-    user_data_script = user_data_script.replace("__EE_COMMIT_HASH__", target_commit)
+    user_data_script1 = user_data_script0.replace("__EE_COMMIT_HASH__", target_commit)
     
-    # Substitute the API token into the user data script.
+    # Apply API token replacement as the second transformation
     api_token = config.require_secret("groundlightApiToken")
-    user_data_script = api_token.apply(
-        lambda token: user_data_script.replace("__GROUNDLIGHTAPITOKEN__", token)
+    user_data_script2 = api_token.apply(
+        lambda token: user_data_script1.replace("__GROUNDLIGHTAPITOKEN__", token)
     )
 
-    return user_data_script
+    return user_data_script2
 
 instance_profile_name = get_instance_profile_by_tag("Name", "edge-device-instance-profile")
 

--- a/cicd/pulumi/__main__.py
+++ b/cicd/pulumi/__main__.py
@@ -51,6 +51,14 @@ def load_user_data_script() -> str:
         user_data_script = file.read()
     target_commit = get_target_commit()
     user_data_script = user_data_script.replace("__EE_COMMIT_HASH__", target_commit)
+    
+    # Substitute the API token into the user data script.
+    api_token_object = config.require_secret("groundlightApiToken")
+    api_token_value = api_token_object.apply(lambda v: v)
+    user_data_script = pulumi.Output.all(api_token_value).apply(
+        lambda values: user_data_script.replace("__GROUNDLIGHTAPITOKEN__", values[0])
+    )
+
     return user_data_script
 
 instance_profile_name = get_instance_profile_by_tag("Name", "edge-device-instance-profile")

--- a/deploy/bin/install-k3s.sh
+++ b/deploy/bin/install-k3s.sh
@@ -53,6 +53,9 @@ fi
 # Set up kubeconfig for the current user
 ./add-k3s-cluster-to-config.sh
 
+echo "You might want to set KUBECONFIG as follows:"
+echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml"
+
 # Install helm
 echo "Installing helm..."
 curl -fsSL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3


### PR DESCRIPTION
Uses `helm-local` for g4 end-to-end test instead of `setup-ee`.  I chose this instead of pushing everything to ECR in order to keep the tests all running in parallel so they're fast instead of serializing this after ECR-push which is after other tests.

Some other good changes along the way:

- Uses API token to get ECR creds instead of ec2 instance profile
- Uses the merge commit, so we're testing what will happen after the merge