### PR TITLE
Adding diagnostics to failed CI/CD runs

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -148,19 +148,8 @@ jobs:
 
       - name: Diagnose failure
         if: failure()
-        env:
-          # Namespace is set in validate_setup_ee.sh
-          NAMESPACE: validate-setup-ee
         run: |
-          set -x
-          set +e
-          df -h
-          kubectl config set-context --current --namespace=$NAMESPACE
-          kubectl get all
-          kubectl describe deployment edge-endpoint
-          kubectl describe pod edge-endpoint
-          kubectl logs deployment/edge-endpoint -c edge-endpoint
-          kubectl logs deployment/edge-endpoint -c inference-model-updater
+          NAMESPACE=validate-setup-ee ./deploy/bin/diagnose-k8-failure.sh
 
   validate-setup-helm:
     runs-on: ubuntu-22.04-8core
@@ -182,19 +171,8 @@ jobs:
 
       - name: Diagnose failure
         if: failure()
-        env:
-          # Namespace is set in validate_setup_helm.sh
-          NAMESPACE: validate-setup-helm
         run: |
-          set -x
-          set +e
-          df -h
-          kubectl config set-context --current --namespace=$NAMESPACE
-          kubectl get all
-          kubectl describe deployment edge-endpoint
-          kubectl describe pod edge-endpoint
-          kubectl logs deployment/edge-endpoint -c edge-endpoint
-          kubectl logs deployment/edge-endpoint -c inference-model-updater
+          NAMESPACE=validate-setup-helm ./deploy/bin/diagnose-k8-failure.sh
 
   # we run this separately from validate-setup-ee since we run out of disk space doing
   # both of them on the same runner and they can be slow so its best to do them in parallel
@@ -240,6 +218,11 @@ jobs:
         run: |
           make test-with-k3s-setup-ee
 
+      - name: Diagnose failure
+        if: failure()
+        run: |
+          NAMESPACE=test-with-k3s ./deploy/bin/diagnose-k8-failure.sh
+
   test-with-k3s-helm:
     runs-on: ubuntu-22.04-8core
     env:
@@ -274,6 +257,11 @@ jobs:
       - name: Run tests with k3s
         run: |
           make test-with-k3s-helm
+
+      - name: Diagnose failure
+        if: failure()
+        run: |
+          NAMESPACE=test-with-k3s-helm ./deploy/bin/diagnose-k8-failure.sh
 
   # Run Groundlight SDK tests against the edge proxy endpoint
   test-sdk:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -107,8 +107,15 @@ jobs:
         run: docker stop ${{ steps.start_container.outputs.container_id }}
 
   validate-setup-ee:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-8core
+    # We'd prefer like to use ubuntu-latest-4-cores, but they're not working.
+    # Standard 2 core doesn't have enough disk space.  (73GB total, 21GB available)
+    # 8core has tons (290GB, 243GB available)
     steps:
+      - name: Show free disk space
+        run: |
+          df -h
+
       - name: Check out code
         uses: actions/checkout@v3
 
@@ -139,8 +146,24 @@ jobs:
         run: |
           make validate-setup-ee
 
+      - name: Diagnose failure
+        if: failure()
+        env:
+          # Namespace is set in validate_setup_ee.sh
+          NAMESPACE: validate-setup-ee
+        run: |
+          set -x
+          set +e
+          df -h
+          kubectl config set-context --current --namespace=$NAMESPACE
+          kubectl get all
+          kubectl describe deployment edge-endpoint
+          kubectl describe pod edge-endpoint
+          kubectl logs deployment/edge-endpoint -c edge-endpoint
+          kubectl logs deployment/edge-endpoint -c inference-model-updater
+
   validate-setup-helm:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-8core
     env:
       # associated with roxanne+test_edge account since for some reason it was failing with
       # prod biggies
@@ -156,6 +179,22 @@ jobs:
       - name: Validate setup edge endpoint
         run: |
           make validate-setup-helm
+
+      - name: Diagnose failure
+        if: failure()
+        env:
+          # Namespace is set in validate_setup_helm.sh
+          NAMESPACE: validate-setup-helm
+        run: |
+          set -x
+          set +e
+          df -h
+          kubectl config set-context --current --namespace=$NAMESPACE
+          kubectl get all
+          kubectl describe deployment edge-endpoint
+          kubectl describe pod edge-endpoint
+          kubectl logs deployment/edge-endpoint -c edge-endpoint
+          kubectl logs deployment/edge-endpoint -c inference-model-updater
 
   # we run this separately from validate-setup-ee since we run out of disk space doing
   # both of them on the same runner and they can be slow so its best to do them in parallel

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -112,10 +112,6 @@ jobs:
     # Standard 2 core doesn't have enough disk space.  (73GB total, 21GB available)
     # 8core has tons (290GB, 243GB available)
     steps:
-      - name: Show free disk space
-        run: |
-          df -h
-
       - name: Check out code
         uses: actions/checkout@v3
 

--- a/deploy/bin/diagnose-k8-failure.sh
+++ b/deploy/bin/diagnose-k8-failure.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Prints a bunch of diagnostics about the k8 status.
+# Run in the CI/CD pipline on test failure.
+
+if [ -z "$NAMESPACE" ]; then
+    CONTEXT=""
+else
+    CONTEXT="-n $NAMESPACE"
+fi
+
+K="kubectl $CONTEXT"
+
+set -x
+set +e  # don't fail on errors - print all the diagnostics, even if some fail
+
+df -h  # sometimes we run out of disk space
+
+$K get all
+$K describe deployment edge-endpoint
+$K describe pod edge-endpoint
+$K logs deployment/edge-endpoint -c edge-endpoint
+$K logs deployment/edge-endpoint -c inference-model-updater
+

--- a/test/integration/setup_and_run_tests_helm.sh
+++ b/test/integration/setup_and_run_tests_helm.sh
@@ -107,10 +107,10 @@ if [ $primary_status -ne 0 ] || [ $oodd_status -ne 0 ]; then
     set +e  # Disable exit on error so all the diagnostic information available gets printed
     echo "Error: One or both inference deployments for detector $DETECTOR_ID failed to rollout within the timeout period."
     echo "Dumping a bunch of diagnostic information..."
-    kubectl describe deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES
-    kubectl logs deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES
-    kubectl describe deployment/inferencemodel-oodd-$DETECTOR_ID_WITH_DASHES
-    kubectl logs deployment/inferencemodel-oodd-$DETECTOR_ID_WITH_DASHES
+    kubectl -n $DEPLOYMENT_NAMESPACE describe deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES
+    kubectl -n $DEPLOYMENT_NAMESPACE logs deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES
+    kubectl -n $DEPLOYMENT_NAMESPACE describe deployment/inferencemodel-oodd-$DETECTOR_ID_WITH_DASHES
+    kubectl -n $DEPLOYMENT_NAMESPACE logs deployment/inferencemodel-oodd-$DETECTOR_ID_WITH_DASHES
     exit 1
 fi
 

--- a/test/integration/setup_and_run_tests_helm.sh
+++ b/test/integration/setup_and_run_tests_helm.sh
@@ -104,6 +104,7 @@ oodd_status=$?
 set -e  # Re-enable exit on error
 
 if [ $primary_status -ne 0 ] || [ $oodd_status -ne 0 ]; then
+    set +e  # Disable exit on error so all the diagnostic information available gets printed
     echo "Error: One or both inference deployments for detector $DETECTOR_ID failed to rollout within the timeout period."
     echo "Dumping a bunch of diagnostic information..."
     kubectl describe deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES

--- a/test/integration/setup_and_run_tests_helm.sh
+++ b/test/integration/setup_and_run_tests_helm.sh
@@ -96,15 +96,20 @@ kubectl rollout status deployment/inferencemodel-oodd-$DETECTOR_ID_WITH_DASHES \
     -n $DEPLOYMENT_NAMESPACE --timeout=10m &
 oodd_pid=$!
 
-# Wait for both background jobs to finish and capture their exit statuses
+set +e  # Temporarily disable exit on error to wait for both background jobs to finish
 wait $primary_pid
 primary_status=$?
-
 wait $oodd_pid
 oodd_status=$?
+set -e  # Re-enable exit on error
 
 if [ $primary_status -ne 0 ] || [ $oodd_status -ne 0 ]; then
     echo "Error: One or both inference deployments for detector $DETECTOR_ID failed to rollout within the timeout period."
+    echo "Dumping a bunch of diagnostic information..."
+    kubectl describe deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES
+    kubectl logs deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES
+    kubectl describe deployment/inferencemodel-oodd-$DETECTOR_ID_WITH_DASHES
+    kubectl logs deployment/inferencemodel-oodd-$DETECTOR_ID_WITH_DASHES
     exit 1
 fi
 

--- a/test/integration/setup_and_run_tests_setup_ee.sh
+++ b/test/integration/setup_and_run_tests_setup_ee.sh
@@ -101,10 +101,10 @@ if [ $primary_status -ne 0 ] || [ $oodd_status -ne 0 ]; then
     set +e  # Disable exit on error so all the diagnostic information available gets printed
     echo "Error: One or both inference deployments for detector $DETECTOR_ID failed to rollout within the timeout period."
     echo "Dumping a bunch of diagnostic information..."
-    kubectl describe deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES
-    kubectl logs deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES
-    kubectl describe deployment/inferencemodel-oodd-$DETECTOR_ID_WITH_DASHES
-    kubectl logs deployment/inferencemodel-oodd-$DETECTOR_ID_WITH_DASHES
+    kubectl -n $DEPLOYMENT_NAMESPACE describe deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES
+    kubectl -n $DEPLOYMENT_NAMESPACE logs deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES
+    kubectl -n $DEPLOYMENT_NAMESPACE describe deployment/inferencemodel-oodd-$DETECTOR_ID_WITH_DASHES
+    kubectl -n $DEPLOYMENT_NAMESPACE logs deployment/inferencemodel-oodd-$DETECTOR_ID_WITH_DASHES
     exit 1
 fi
 

--- a/test/integration/setup_and_run_tests_setup_ee.sh
+++ b/test/integration/setup_and_run_tests_setup_ee.sh
@@ -98,6 +98,7 @@ oodd_status=$?
 set -e  # Re-enable exit on error
 
 if [ $primary_status -ne 0 ] || [ $oodd_status -ne 0 ]; then
+    set +e  # Disable exit on error so all the diagnostic information available gets printed
     echo "Error: One or both inference deployments for detector $DETECTOR_ID failed to rollout within the timeout period."
     echo "Dumping a bunch of diagnostic information..."
     kubectl describe deployment/inferencemodel-primary-$DETECTOR_ID_WITH_DASHES


### PR DESCRIPTION
Adding diagnose-failure steps to the validate-* workflow jobs, which show what happened inside kubernetes on a failure.