### PR TITLE
(small) fix pre-release pipeline action

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -511,6 +511,20 @@ jobs:
       - main-tests-pass
     runs-on: ubuntu-latest
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_GL_PUBLIC_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_GL_PUBLIC_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: "true"
+      - name: Check out code
+        uses: actions/checkout@v4
+
       - name: Tag main images with the "pre-release" tag after all the tests pass
         run: ./deploy/bin/tag-edge-endpoint-image.sh pre-release
 


### PR DESCRIPTION
Refactoring blunder.  You gotta checkout the code and get the credentials before you can run the ECR script.  Derp.