### PR TITLE
Send edge results to cloud

### DIFF
--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -4,9 +4,7 @@ from typing import Literal, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
 from groundlight import Groundlight
-from model import (
-    ImageQuery,
-)
+from model import ImageQuery
 
 from app.core.app_state import (
     AppState,
@@ -187,7 +185,10 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
                         patience_time=patience_time,
                         confidence_threshold=confidence_threshold,
                         want_async=True,
-                        metadata={"is_edge_audit": True},  # This metadata will trigger an audit in the cloud
+                        metadata={
+                            "is_edge_audit": True,  # This metadata will trigger an audit in the cloud
+                            "edge_result": results,
+                        },
                         image_query_id=image_query.id,  # We give the cloud IQ the same ID as the returned edge IQ
                     )
 
@@ -211,6 +212,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
                         confidence_threshold=confidence_threshold,
                         human_review=human_review,
                         want_async=True,
+                        metadata={"edge_result": results},
                         image_query_id=image_query.id,  # Ensure the cloud IQ has the same ID as the returned edge IQ
                     )
                 else:

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -113,6 +113,9 @@ def adjust_confidence_with_oodd(primary_output_dict: dict, oodd_output_dict: dic
 
     adjusted_output_dict = primary_output_dict.copy()
     adjusted_output_dict["confidence"] = adjusted_confidence
+    # Raw prediction data for troubleshooting purposes
+    adjusted_output_dict["raw_primary_confidence"] = primary_output_dict["confidence"]
+    adjusted_output_dict["raw_oodd_prediction"] = oodd_output_dict.copy()
 
     return adjusted_output_dict
 


### PR DESCRIPTION
* Add raw predictions to edge results dict
* Send edge results when escalating or auditing image queries

Manual verification on local edge deployment with logLevel=DEBUG: 
```
2025-04-02 05:18:03.044 DEBUG Inference server response for request detector_id='det_2ub7ro76kcZBBScqU752agizg6y': {'confidence': 0.2025984217867059, 'label': 2, 'text': None, 'rois': [{'label': 'person', 'geometry': {'left': 0.5553668975830078, 'top': 0.17134240864448588, 'right': 0.7196331024169922, 'bottom': 0.2721633991696641, 'version': '2.0', 'x': 0.6375, 'y': 0.22175290390707497}, 'score': 1.0, 'version': '2.0'}, {'label': 'person', 'geometry': {'left': 0.4058767954508464, 'top': 0.12688064978014454, 'right': 0.5357898712158203, 'bottom': 0.20680467228954924, 'version': '2.0', 'x': 0.4708333333333333, 'y': 0.1668426610348469}, 'score': 1.0, 'version': '2.0'}], 'raw_primary_confidence': 0.9998700618743896, 'raw_oodd_prediction': {'confidence': 0.8698741853551043, 'label': 1.0, 'text': None, 'rois': None}}.
```
And when escalation occurs due to low confidence 
(** Note: this works only with `edge_answers_with_escalation` configuration and not with `default` configuration because the edge prediction is ignored there if underconfident **): 
```
In [36]: gl_edge.ask_ml(detector=det_id, image=img59_path)
Out[36]: ImageQuery(metadata={'is_from_edge': True}, id='iq_2vA0GpuaNgGahGIaZVyqMSECJ4R', type=<ImageQueryTypeEnum.image_query: 'image_query'>, created_at=datetime.datetime(2025, 4, 2, 5, 41, 17, 906778, tzinfo=tzlocal()), query='Label each person in the image', detector_id='det_2ub7ro76kcZBBScqU752agizg6y', result_type=<ResultTypeEnum.counting: 'counting'>, result=CountingResult(confidence=0.2025984217867059, source=<Source.ALGORITHM: 'ALGORITHM'>, result_type=None, count=2, greater_than_max=False), patience_time=30.0, confidence_threshold=0.9, rois=[ROI(label='person', score=1.0, geometry=BBoxGeometry(left=0.5553668975830078, top=0.17134240864448588, right=0.7196331024169922, bottom=0.2721633991696641, x=0.6375, y=0.22175290390707497)), ROI(label='person', score=1.0, geometry=BBoxGeometry(left=0.4058767954508464, top=0.12688064978014454, right=0.5357898712158203, bottom=0.20680467228954924, x=0.4708333333333333, y=0.1668426610348469))], text=None, done_processing=False)

In [38]: gl_cloud.get_image_query(id="iq_2vA0GpuaNgGahGIaZVyqMSECJ4R")
Out[38]: ImageQuery(metadata={'edge_result': {'rois': [{'label': 'person', 'score': 1.0, 'version': '2.0', 'geometry': {'x': 0.6375, 'y': 0.22175290390707497, 'top': 0.17134240864448588, 'left': 0.5553668975830078, 'right': 0.7196331024169922, 'bottom': 0.2721633991696641, 'version': '2.0'}}, {'label': 'person', 'score': 1.0, 'version': '2.0', 'geometry': {'x': 0.4708333333333333, 'y': 0.1668426610348469, 'top': 0.12688064978014454, 'left': 0.4058767954508464, 'right': 0.5357898712158203, 'bottom': 0.20680467228954924, 'version': '2.0'}}], 'text': None, 'label': 2, 'confidence': 0.2025984217867059, 'raw_oodd_prediction': {'rois': None, 'text': None, 'label': 1.0, 'confidence': 0.8698741853551043}, 'raw_primary_confidence': 0.9998700618743896}, 'is_from_edge': True}, id='iq_2vA0GpuaNgGahGIaZVyqMSECJ4R', type=<ImageQueryTypeEnum.image_query: 'image_query'>, created_at=datetime.datetime(2025, 4, 2, 5, 41, 18, 56978, tzinfo=tzlocal()), query='Label each person in the image', detector_id='det_2ub7ro76kcZBBScqU752agizg6y', result_type=<ResultTypeEnum.counting: 'counting'>, result=CountingResult(confidence=0.32423293973145256, source=<Source.ALGORITHM: 'ALGORITHM'>, result_type=<ResultType2.counting: 'counting'>, count=2, greater_than_max=False), patience_time=30.0, confidence_threshold=0.9, rois=[ROI(label='person', score=1.0, geometry=BBoxGeometry(left=0.5611035029093424, top=0.17464970133978605, right=0.7138964970906575, bottom=0.26838827334375825, x=0.6375, y=0.22151898734177217)), ROI(label='person', score=1.0, geometry=BBoxGeometry(left=0.3981670697530111, top=0.1219972538042672, right=0.5434996287027994, bottom=0.2113360795290661, x=0.47083334922790526, y=0.16666666666666666))], text=None, done_processing=False)
```