### PR TITLE
Send any edge results on to the cloud in default mode when unconfident

### DIFF
--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -139,6 +139,9 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
 
     confidence_threshold = confidence_threshold or detector_metadata.confidence_threshold
 
+    # for holding edge results if and when available
+    results = None
+
     if require_human_review:
         # If human review is required, we should skip edge inference completely
         logger.debug("Received human_review=ALWAYS. Skipping edge inference.")
@@ -270,4 +273,5 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
         patience_time=patience_time,
         confidence_threshold=confidence_threshold,
         human_review=human_review,
+        metadata={"edge_result": results},
     )


### PR DESCRIPTION
Submitting an image that the edge model could not answer confidently in "default" config mode. 
Before (no metadata): 
```
In [7]: gl_edge.submit_image_query(detector=det_id, image=img5_path)
Out[7]: ImageQuery(metadata=None, id='iq_2vH1L5GA6ATK5COHMf5LTvrrAqM', type=<ImageQueryTypeEnum.image_query: 'image_query'>, created_at=datetime.datetime(2025, 4, 4, 17, 18, 46, 15922, tzinfo=tzlocal()), query='Label each person in the image', detector_id='det_2ub7ro76kcZBBScqU752agizg6y', result_type=<ResultTypeEnum.counting: 'counting'>, result=CountingResult(confidence=0.41899670768056946, source='ALGORITHM', result_type='counting', from_edge=False, count=2, greater_than_max=False), patience_time=30.0, confidence_threshold=0.9, rois=[ROI(label='person', score=1.0, geometry=BBoxGeometry(left=0.27836809158325193, top=0.7859052183255868, right=0.4466319084167481, bottom=0.8892002669064808, x=0.36250000000000004, y=0.8375527426160339)), ROI(label='person', score=1.0, geometry=BBoxGeometry(left=0.4765168507893881, top=0.8683964854051293, right=0.5818164825439454, bottom=0.933291278307951, x=0.5291666666666668, y=0.9008438818565401))], text=None, done_processing=False)
```
After (`edge_result` metadata, but still no `from_edge` because we did not create an edge image query):
```
In [10]: gl_edge.submit_image_query(detector=det_id, image=img5_path)
Out[10]: ImageQuery(metadata={'edge_result': {'rois': [{'label': 'person', 'score': 1.0, 'version': '2.0', 'geometry': {'x': 0.35416666666666663, 'y': 0.8384371700105597, 'top': 0.789503989778577, 'left': 0.27455482482910154, 'right': 0.4337785085042318, 'bottom': 0.8873703502425423, 'version': '2.0'}}, {'label': 'person', 'score': 1.0, 'version': '2.0', 'geometry': {'x': 0.5208333333333334, 'y': 0.9017951425554382, 'top': 0.8653021775178195, 'left': 0.4617378870646159, 'right': 0.5799287796020508, 'bottom': 0.938288107593057, 'version': '2.0'}}], 'text': None, 'label': 2, 'confidence': 0.23436624775871984, 'raw_oodd_prediction': {'rois': None, 'text': None, 'label': 1.0, 'confidence': 0.8352134620226286}, 'raw_primary_confidence': 0.9998700618743896}}, id='iq_2vH3G2foHVHXr5rsXDKEpc82yYo', type=<ImageQueryTypeEnum.image_query: 'image_query'>, created_at=datetime.datetime(2025, 4, 4, 17, 34, 32, 631280, tzinfo=tzlocal()), query='Label each person in the image', detector_id='det_2ub7ro76kcZBBScqU752agizg6y', result_type=<ResultTypeEnum.counting: 'counting'>, result=CountingResult(confidence=0.41899670768056946, source='ALGORITHM', result_type='counting', from_edge=False, count=2, greater_than_max=False), patience_time=30.0, confidence_threshold=0.9, rois=[ROI(label='person', score=1.0, geometry=BBoxGeometry(left=0.27836809158325193, top=0.7859052183255868, right=0.4466319084167481, bottom=0.8892002669064808, x=0.36250000000000004, y=0.8375527426160339)), ROI(label='person', score=1.0, geometry=BBoxGeometry(left=0.4765168507893881, top=0.8683964854051293, right=0.5818164825439454, bottom=0.933291278307951, x=0.5291666666666668, y=0.9008438818565401))], text=None, done_processing=False)
```