### PR TITLE
Handle the fact that ELBs change IP addresses

### DIFF
--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -36,17 +36,8 @@ http {
         }
 
         location @fallback {
-            # Note: the comment below describes how we use `resolver` in the helm version
-            # of this config, but we don't use it here because it doesn't work when you
-            # run the docker container outside of Kubernetes, which we do during testing.
-            # This is the default resolver for Kubernetes. We need to set it explicitly
-            # and put the fallback server in a varible to get nginx to resolve it regularly.
-            # This is important when going to an AWS ELB because the IPs change.
-            # resolver 10.43.0.10 valid=30s;
-            set $upstreamEndpoint https://api.groundlight.ai;
-
             # Fallback to the cloud API server
-            proxy_pass $upstreamEndpoint;
+            proxy_pass https://api.groundlight.ai;
         }
 
     }

--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -36,8 +36,14 @@ http {
         }
 
         location @fallback {
+            # This is the default resolver for Kubernetes. We need to set it explicitly
+            # and put the fallback server in a varible to get nginx to resolve it regularly.
+            # This is important when going to an AWS ELB because the IPs change.
+            resolver 10.43.0.10 valid=30s;
+            set $upstreamEndpoint https://api.groundlight.ai;
+
             # Fallback to the cloud API server
-            proxy_pass https://api.groundlight.ai;
+            proxy_pass $upstreamEndpoint;
         }
 
     }

--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -36,10 +36,13 @@ http {
         }
 
         location @fallback {
+            # Note: the comment below describes how we use `resolver` in the helm version
+            # of this config, but we don't use it here because it doesn't work when you
+            # run the docker container outside of Kubernetes, which we do during testing.
             # This is the default resolver for Kubernetes. We need to set it explicitly
             # and put the fallback server in a varible to get nginx to resolve it regularly.
             # This is important when going to an AWS ELB because the IPs change.
-            resolver 10.43.0.10 valid=30s;
+            # resolver 10.43.0.10 valid=30s;
             set $upstreamEndpoint https://api.groundlight.ai;
 
             # Fallback to the cloud API server

--- a/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
+++ b/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
@@ -2,6 +2,8 @@ events {
     worker_connections 256;
 }
 
+
+
 http {
     # Add "NGINX: " prefix to the log entries to distinguish them from other logs.
     # Follows NGINX's default "combined" log format.
@@ -36,9 +38,15 @@ http {
         }
 
         location @fallback {
-            # Fallback to the cloud API server
+            # This is the default resolver for Kubernetes. We need to set it explicitly
+            # and put the fallback server in a varible to get nginx to resolve it regularly.
+            # This is important when going to an AWS ELB because the IPs change.
+            resolver 10.43.0.10 valid=30s;
             {{- $parsedURL := .Values.upstreamEndpoint | urlParse }}
-            proxy_pass {{  index $parsedURL "scheme" }}://{{ index $parsedURL "host" }};
+            set $upstreamEndpoint {{  index $parsedURL "scheme" }}://{{ index $parsedURL "host" }};
+
+            # Fallback to the cloud API server
+            proxy_pass $upstreamEndpoint;
         }
 
     }

--- a/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
+++ b/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
@@ -2,8 +2,6 @@ events {
     worker_connections 256;
 }
 
-
-
 http {
     # Add "NGINX: " prefix to the log entries to distinguish them from other logs.
     # Follows NGINX's default "combined" log format.

--- a/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
+++ b/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
@@ -37,7 +37,7 @@ http {
 
         location @fallback {
             # This is the default resolver for Kubernetes. We need to set it explicitly
-            # and put the fallback server in a varible to get nginx to resolve it regularly.
+            # and put the fallback server in a variable to get nginx to resolve it regularly.
             # This is important when going to an AWS ELB because the IPs change.
             resolver 10.43.0.10 valid=30s;
             {{- $parsedURL := .Values.upstreamEndpoint | urlParse }}


### PR DESCRIPTION
This should deal with the fallback upstream URL in our edge-endpoint breaking after a while because the ELB changes its IP address. 

I only made this change for the helm version since making it for the `setup-ee.sh` version would have required us to do a bunch of duplication and/or scripting (so that the docker tests would continue to pass). Since we're deprecating that version, I figured I wouldn't create that mess.

I think the python SDK may have a similar problem for long-running programs (like the edge-endpoint app), but I need to explore that further.