### PR TITLE
Don't include `results` in metadata if it would pass the max allowed size

### DIFF
--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -14,7 +14,7 @@ from app.core.app_state import (
     refresh_detector_metadata_if_needed,
 )
 from app.core.edge_inference import get_edge_inference_model_name
-from app.core.utils import create_iq, safe_call_sdk
+from app.core.utils import create_iq, generate_metadata_dict, safe_call_sdk
 from app.metrics.iqactivity import record_iq_activity
 
 logger = logging.getLogger(__name__)
@@ -191,10 +191,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
                         patience_time=patience_time,
                         confidence_threshold=confidence_threshold,
                         want_async=True,
-                        metadata={
-                            "is_edge_audit": True,  # This metadata will trigger an audit in the cloud
-                            "edge_result": results,
-                        },
+                        metadata=generate_metadata_dict(results=results, is_edge_audit=True),
                         image_query_id=image_query.id,  # We give the cloud IQ the same ID as the returned edge IQ
                     )
 
@@ -218,7 +215,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
                         confidence_threshold=confidence_threshold,
                         human_review=human_review,
                         want_async=True,
-                        metadata={"edge_result": results},
+                        metadata=generate_metadata_dict(results=results, is_edge_audit=False),
                         image_query_id=image_query.id,  # Ensure the cloud IQ has the same ID as the returned edge IQ
                     )
                 else:
@@ -273,5 +270,5 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
         patience_time=patience_time,
         confidence_threshold=confidence_threshold,
         human_review=human_review,
-        metadata={"edge_result": results},
+        metadata=generate_metadata_dict(results=results, is_edge_audit=False),
     )

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -145,7 +145,7 @@ def generate_metadata_dict(results: dict[str, Any] | None, is_edge_audit: bool =
     """
     Generates the metadata for an IQ being escalated to the cloud.
     Includes `"is_edge_audit": True` if it is an edge audit.
-    Includes `"edge_result": results` if including the results would not push the size over the max allowable size.
+    Includes `"edge_result": results` if including the results would not push the metadata over the size limit.
     """
     metadata_dict = {}
 

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -157,6 +157,10 @@ def generate_metadata_dict(results: dict[str, Any] | None, is_edge_audit: bool =
     size_bytes = len(metadata_json)
     if size_bytes > METADATA_SIZE_LIMIT_BYTES:
         metadata_dict.pop("edge_result")
+        logger.debug(
+            f"Inference results were {size_bytes} bytes, which made the metadata larger than the max allowed size of "
+            f"{METADATA_SIZE_LIMIT_BYTES} bytes. Not including the results in the metadata."
+        )
 
     return metadata_dict
 

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -156,7 +156,8 @@ def generate_metadata_dict(results: dict[str, Any] | None, is_edge_audit: bool =
     """
     Generates the metadata for an IQ being escalated to the cloud.
     Includes `"is_edge_audit": True` if it is an edge audit.
-    Includes `"edge_result": results` if including the results would not push the metadata over the size limit.
+    Includes `"edge_result": results` if including the results would not push the metadata over the size limit. If they
+        would, includes the results without the ROIs if the resulting metadata does not exceed the limit.
     """
     metadata_dict = {}
 

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -27,7 +27,9 @@ from app.core import constants
 
 logger = logging.getLogger(__name__)
 
-METADATA_SIZE_LIMIT_BYTES = 1024
+METADATA_SIZE_LIMIT_BYTES = (
+    1024  # This is defined in the SDK and will need to be manually updated here if it gets modified
+)
 
 
 def create_iq(  # noqa: PLR0913

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -141,15 +141,20 @@ def safe_call_sdk(api_method: Callable, **kwargs):
         raise ex
 
 
-def _size_of_dict_with_field(initial_dict: dict[str, Any], new_data_key: str, new_data_value: Any) -> int:
+def _size_of_dict_in_bytes(data: dict[str, Any]) -> int:
+    """Returns the size, in # of bytes (assuming all ASCII characters), of the provided dict."""
+    data_json = json.dumps(data)
+    return len(data_json)
+
+
+def _size_of_dict_with_field_in_bytes(initial_dict: dict[str, Any], new_data_key: str, new_data_value: Any) -> int:
     """
-    Returns the size, in # of bytes (assuming all ASCII characters), of the provided dict if it includes the provided
+    Returns the size, in # of bytes (assuming all ASCII characters), of the provided dict if it included the provided
     key/value pair.
     """
     combined_dict = initial_dict.copy()
     combined_dict[new_data_key] = new_data_value
-    combined_json = json.dumps(combined_dict)
-    return len(combined_json)
+    return _size_of_dict_in_bytes(combined_dict)
 
 
 def generate_metadata_dict(results: dict[str, Any] | None, is_edge_audit: bool = False) -> dict[str, Any]:
@@ -164,7 +169,7 @@ def generate_metadata_dict(results: dict[str, Any] | None, is_edge_audit: bool =
     if is_edge_audit:
         metadata_dict["is_edge_audit"] = True  # This metadata will trigger an audit in the cloud
 
-    metadata_with_results_size = _size_of_dict_with_field(metadata_dict, "edge_result", results)
+    metadata_with_results_size = _size_of_dict_with_field_in_bytes(metadata_dict, "edge_result", results)
     if metadata_with_results_size > METADATA_SIZE_LIMIT_BYTES:
         logger.debug(
             f"Inference results were {metadata_with_results_size} bytes, which made the metadata larger than the max "
@@ -173,7 +178,9 @@ def generate_metadata_dict(results: dict[str, Any] | None, is_edge_audit: bool =
         results_without_rois = results.copy()
         if "rois" in results_without_rois:
             results_without_rois["rois"] = f"{len(results['rois'])} ROIs were detected."
-            metadata_with_results_size = _size_of_dict_with_field(metadata_dict, "edge_result", results_without_rois)
+            metadata_with_results_size = _size_of_dict_with_field_in_bytes(
+                metadata_dict, "edge_result", results_without_rois
+            )
             if metadata_with_results_size <= METADATA_SIZE_LIMIT_BYTES:
                 metadata_dict["edge_result"] = results_without_rois
             else:

--- a/test/api/test_utils.py
+++ b/test/api/test_utils.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from model import (
     BinaryClassificationResult,
@@ -9,13 +11,132 @@ from model import (
 )
 
 from app.core.utils import (
+    METADATA_SIZE_LIMIT_BYTES,
     ModelInfoBase,
     ModelInfoNoBinary,
     ModelInfoWithBinary,
+    _size_of_dict_in_bytes,
     create_iq,
+    generate_metadata_dict,
     parse_model_info,
     prefixed_ksuid,
 )
+
+
+class TestGenerateMetadataDict:
+    def setup_method(self):
+        pass
+
+    @pytest.fixture
+    def basic_binary_result(self):
+        return {
+            "confidence": 0.84,
+            "label": 1,
+            "text": None,
+            "rois": None,
+            "raw_primary_confidence": 0.84,
+            "raw_oodd_prediction": {"confidence": 1.0, "label": 0.0, "text": None, "rois": None},
+        }
+
+    @pytest.fixture
+    def basic_count_result(self):
+        return {
+            "confidence": 0.08,
+            "label": 1,
+            "text": None,
+            "rois": [
+                {
+                    "label": "bird",
+                    "geometry": {
+                        "left": 0.40,
+                        "top": 0.40,
+                        "right": 0.60,
+                        "bottom": 0.60,
+                        "version": "2.0",
+                        "x": 0.50,
+                        "y": 0.50,
+                    },
+                    "score": 0.80,
+                    "version": "2.0",
+                }
+            ],
+            "raw_primary_confidence": 0.08,
+            "raw_oodd_prediction": {"confidence": 1.0, "label": 0.0, "text": None, "rois": None},
+        }
+
+    @pytest.fixture
+    def many_rois_count_result(self):
+        return {
+            "confidence": 0.08,
+            "label": 10,
+            "text": None,
+            "rois": [
+                {
+                    "label": "bird",
+                    "geometry": {
+                        "left": 0.40,
+                        "top": 0.40,
+                        "right": 0.60,
+                        "bottom": 0.60,
+                        "version": "2.0",
+                        "x": 0.50,
+                        "y": 0.50,
+                    },
+                    "score": 0.80,
+                    "version": "2.0",
+                }
+            ]
+            * 10,  # contains 10 ROI objects
+            "raw_primary_confidence": 0.08,
+            "raw_oodd_prediction": {"confidence": 1.0, "label": 0.0, "text": None, "rois": None},
+        }
+
+    def _assert_metadata_within_size_limit(self, metadata: dict[str, Any]):
+        assert _size_of_dict_in_bytes(metadata) < METADATA_SIZE_LIMIT_BYTES
+
+    def test_metadata_dict_no_results(self):
+        """Test generating metadata without providing a response dict."""
+        metadata = generate_metadata_dict(results=None)
+        expected_metadata = {"edge_result": None}
+        assert metadata == expected_metadata
+
+        metadata = generate_metadata_dict(results=None, is_edge_audit=True)
+        expected_metadata = {"edge_result": None, "is_edge_audit": True}
+        assert metadata == expected_metadata
+
+    def test_basic_binary_metadata_dict(self, basic_binary_result: dict[str, Any]):
+        """Test generating metadata for a simple binary response."""
+        metadata = generate_metadata_dict(results=basic_binary_result)
+        expected_metadata = {"edge_result": basic_binary_result}
+
+        assert metadata == expected_metadata
+        self._assert_metadata_within_size_limit(metadata)
+
+    def test_binary_metadata_dict_with_audit(self, basic_binary_result: dict[str, Any]):
+        """Test generating metadata for a simple binary response which is also an edge audit."""
+        metadata = generate_metadata_dict(results=basic_binary_result, is_edge_audit=True)
+        expected_metadata = {"edge_result": basic_binary_result, "is_edge_audit": True}
+
+        assert metadata == expected_metadata
+        self._assert_metadata_within_size_limit(metadata)
+
+    def test_basic_count_metadata_dict(self, basic_count_result: dict[str, Any]):
+        """Test generating metadata for a simple count response."""
+        metadata = generate_metadata_dict(results=basic_count_result)
+        expected_metadata = {"edge_result": basic_count_result}
+
+        assert metadata == expected_metadata
+        self._assert_metadata_within_size_limit(metadata)
+
+    def test_count_metadata_dict_many_rois_with_audit(self, many_rois_count_result: dict[str, Any]):
+        "Test generating metadata for a count response with many ROIs that will exceed the size limit."
+        metadata = generate_metadata_dict(results=many_rois_count_result, is_edge_audit=True)
+        modified_results = many_rois_count_result.copy()
+        modified_results["rois"] = f"{len(many_rois_count_result['rois'])} ROIs were detected."
+        expected_metadata = {"edge_result": modified_results, "is_edge_audit": True}
+
+        assert metadata == expected_metadata
+        self._assert_metadata_within_size_limit(metadata)
 
 
 class TestCreateIQ:


### PR DESCRIPTION
Previously, with ~7+ ROIs in the `results` dict, cloud escalations would fail because the metadata exceeded the maximum allowed size. This ensures we don't exceed the size and restricts the contents of the `results` data if necessary.

The max size is defined [here](https://github.com/groundlight/python-sdk/blob/67c8d291da33f7b42302fa49c08bc73745210f68/src/groundlight/client.py#L342) in the SDK. Unfortunately the number is hard-coded in, so if it changes in the SDK we'll have to manually update it here.