### PR TITLE
Configurable log level and move noisy logs to DEBUG

### DIFF
--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -339,7 +339,7 @@ class EdgeInferenceManager:
         update_oodd_model = should_update(oodd_model_info, oodd_model_dir, oodd_version)
 
         if not update_primary_model and not update_oodd_model:
-            logger.info(f"No new models available for {detector_id}")
+            logger.debug(f"No new models available for {detector_id}")
             return False
 
         logger.info(f"At least one new model is available for {detector_id}, saving models to repository.")

--- a/app/main.py
+++ b/app/main.py
@@ -22,7 +22,9 @@ DEPLOY_DETECTOR_LEVEL_INFERENCE = bool(int(os.environ.get("DEPLOY_DETECTOR_LEVEL
 logging.basicConfig(
     level=LOG_LEVEL, format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
 )
-
+# The asyncio executor is too verbose at INFO level, so we set it to WARNING
+if LOG_LEVEL == "INFO":
+    logging.getLogger("apscheduler.executors.default").setLevel(logging.WARNING)
 
 app = FastAPI(title="edge-endpoint")
 app.include_router(router=api_router, prefix=API_BASE_PATH)
@@ -34,7 +36,7 @@ scheduler = AsyncIOScheduler()
 
 def update_inference_config(app_state: AppState) -> None:
     """Update the App's edge-inference config by querying the database for new detectors."""
-    logging.info("Querying database for updated inference deployment records...")
+    logging.debug("Querying database for updated inference deployment records...")
     detectors = app_state.db_manager.get_inference_deployment_records(deployment_created=True)
     if detectors:
         for detector_record in detectors:

--- a/app/model_updater/update_models.py
+++ b/app/model_updater/update_models.py
@@ -133,7 +133,7 @@ def manage_update_models(
 
     while True:
         start = time.time()
-        logger.info("Starting model update check for existing inference deployments.")
+        logger.debug("Starting model update check for existing inference deployments.")
         for detector_id in edge_inference_manager.detector_inference_configs.keys():
             try:
                 logger.debug(f"Checking new models and inference deployments for detector_id: {detector_id}")
@@ -143,19 +143,19 @@ def manage_update_models(
                     deployment_manager=deployment_manager,
                     db_manager=db_manager,
                 )
-                logger.info(f"Successfully updated model for detector_id: {detector_id}")
+                logger.debug(f"Successfully updated model for detector_id: {detector_id}")
             except Exception as e:
-                logger.error(f"Failed to update model for detector_id: {detector_id}. Error: {e}", exc_info=True)
+                logger.info(f"Failed to update model for detector_id: {detector_id}. Error: {e}", exc_info=True)
 
         elapsed_s = time.time() - start
-        logger.info(f"Model update check completed in {elapsed_s:.2f} seconds.")
+        logger.debug(f"Model update check completed in {elapsed_s:.2f} seconds.")
         if elapsed_s < refresh_rate:
             sleep_duration = refresh_rate - elapsed_s
-            logger.info(f"Sleeping for {sleep_duration:.2f} seconds before next update cycle.")
+            logger.debug(f"Sleeping for {sleep_duration:.2f} seconds before next update cycle.")
             time.sleep(sleep_duration)
 
         # Fetch detector IDs that need to be deployed from the database and add them to the config
-        logger.info("Fetching undeployed detector IDs from the database.")
+        logger.debug("Fetching undeployed detector IDs from the database.")
         undeployed_detector_ids = db_manager.get_inference_deployment_records(deployment_created=False)
         if undeployed_detector_ids:
             logger.info(f"Found {len(undeployed_detector_ids)} undeployed detectors. Updating inference config.")
@@ -165,7 +165,7 @@ def manage_update_models(
                     detector_id=detector_record.detector_id, api_token=detector_record.api_token
                 )
         else:
-            logger.info("No undeployed detectors found.")
+            logger.debug("No undeployed detectors found.")
 
         # Update the status of the inference deployments in the database
         deployment_records = db_manager.get_inference_deployment_records()

--- a/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
@@ -71,6 +71,8 @@ spec:
           value: placeholder-model-name
         - name: PINAMOD_DIR
           value: /opt/models/pinamod
+        - name: LOG_LEVEL
+          value: {{ .Values.logLevel | quote }}
         command:
           [
             "poetry", "run", "python3", "-m", "uvicorn", "serving.edge_inference_server.fastapi_server:app",

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         - containerPort: 30101
         env:
         - name: LOG_LEVEL
-          value: "INFO"
+          value: {{ .Values.logLevel | quote }}
         # We need this feature flag since we run the edge logic server in two separate environments:
         # 1. In docker (on the GitHub Actions runner) for testing
         # 2. In kubernetes (currently a dedicated EC2 instance)
@@ -119,7 +119,7 @@ spec:
         command: ["./app/bin/launch-status-monitor.sh"]
         env:
         - name: LOG_LEVEL
-          value: "INFO"
+          value: {{ .Values.logLevel | quote }}
         - name: GROUNDLIGHT_API_TOKEN
           valueFrom:
             secretKeyRef:
@@ -139,7 +139,7 @@ spec:
         args: ["poetry run python -m app.model_updater.update_models"]
         env:
         - name: LOG_LEVEL
-          value: "INFO"
+          value: {{ .Values.logLevel | quote }}
         - name: DEPLOY_DETECTOR_LEVEL_INFERENCE
           value: "1"
         - name: GROUNDLIGHT_ENDPOINT

--- a/deploy/helm/groundlight-edge-endpoint/values.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/values.yaml
@@ -25,7 +25,7 @@ imagePullPolicy: "Always"
 # namespace if you've overriden the default value).
 edgeEndpointPort: 30101
 
-# This is used as the base of the name for the PeristentVolume. The full name of the volume is 
+# This is used as the base of the name for the PersistentVolume. The full name of the volume is 
 # created by appending the namespace to this value. Generally, this should not be overridden.
 # The PersistentVolume is used to store the model files and other data that the Edge Endpoint wants
 # to persist between restarts. It is mapped to `/opt/groundlight/edge` on the host.
@@ -48,6 +48,9 @@ upstreamEndpoint: "https://api.groundlight.ai"
 awsRegion: "us-west-2"
 
 ecrRegistry: "767397850842.dkr.ecr.us-west-2.amazonaws.com"
+
+# This sets the log level for all the containers, both edge endpoint and inference.
+logLevel: "INFO"
 
 # These values override the automated settings in _helpers.tpl to keep this short and sweet
 # Don't override these


### PR DESCRIPTION
This PR does two things:
1. Make it so you can configure the log level for the apps in the helm deploy step with `--set logLevel=DEBUG` or whatever.
2. Move some noisy logs from `INFO` to `DEBUG` so the logs will focus more on what's really happening.

When the system is doing nothing, the only noisy logs come from health checks.