### PR TITLE
Log activity hour for activity metrics

### DIFF
--- a/app/metrics/iq_activity.py
+++ b/app/metrics/iq_activity.py
@@ -132,7 +132,7 @@ class ActivityRetriever:
         active_detectors = [
             file.parent.name
             for file in activity_files
-            if _tracker().get_last_file_modification_time(file) > datetime.now(timezone.utc) - time_period
+            if _tracker().get_last_file_modification_time(file) > datetime.now() - time_period
         ]
         return len(active_detectors)
 
@@ -191,7 +191,7 @@ def record_activity_for_metrics(detector_id: str, activity_type: str):
 
     logger.debug(f"Recording activity {activity_type} on detector {detector_id}")
 
-    current_hour = datetime.now(timezone.utc)
+    current_hour = datetime.now()
     f = _tracker().hourly_activity_file(activity_type, current_hour, detector_id)
     _tracker().increment_counter_file(f)
 
@@ -201,9 +201,9 @@ def record_activity_for_metrics(detector_id: str, activity_type: str):
 
 def clear_old_activity_files():
     """Clear all activity files that are older than 2 hours."""
-    current_hour = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H")
-    last_hour = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime("%Y-%m-%d_%H")
-    two_hours_ago = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime("%Y-%m-%d_%H")
+    current_hour = datetime.now().strftime("%Y-%m-%d_%H")
+    last_hour = (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%d_%H")
+    two_hours_ago = (datetime.now() - timedelta(hours=2)).strftime("%Y-%m-%d_%H")
     valid_hours = [current_hour, last_hour, two_hours_ago]
 
     # Looking for files that match the pattern <record_name>_YYYY-MM-DD_HH

--- a/app/metrics/iq_activity.py
+++ b/app/metrics/iq_activity.py
@@ -145,9 +145,13 @@ class ActivityRetriever:
         # the individual detector fields
         return json.dumps(detector_activity)
 
+    def get_last_hour(self) -> str:
+        """Get the last hour in UTC."""
+        return (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%d_%H")
+
     def get_detector_activity_metrics(self, detector_id: str) -> int:
         """Get the activity on a detector for the previous hour."""
-        time = (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%d_%H")
+        time = self.get_last_hour()
         logger.info(f"Getting activity for detector {detector_id} at {time}")
 
         detector_folder = _tracker().detector_folder(detector_id)

--- a/app/metrics/metric_reporting.py
+++ b/app/metrics/metric_reporting.py
@@ -67,6 +67,7 @@ class MetricsReporter:
 
         activity_metrics = SafeMetricsDict()
         retriever = iq_activity.ActivityRetriever()
+        activity_metrics.add("log_hour", lambda: retriever.get_last_hour())
         activity_metrics.add("last_activity_time", lambda: retriever.last_activity_time())
         activity_metrics.add("num_detectors_lifetime", lambda: retriever.num_detectors_lifetime())
         activity_metrics.add("num_detectors_active_1h", lambda: retriever.num_detectors_active(timedelta(hours=1)))

--- a/app/metrics/metric_reporting.py
+++ b/app/metrics/metric_reporting.py
@@ -67,7 +67,7 @@ class MetricsReporter:
 
         activity_metrics = SafeMetricsDict()
         retriever = iq_activity.ActivityRetriever()
-        activity_metrics.add("log_hour", lambda: retriever.get_last_hour())
+        activity_metrics.add("activity_hour", lambda: retriever.get_last_hour())
         activity_metrics.add("last_activity_time", lambda: retriever.last_activity_time())
         activity_metrics.add("num_detectors_lifetime", lambda: retriever.num_detectors_lifetime())
         activity_metrics.add("num_detectors_active_1h", lambda: retriever.num_detectors_active(timedelta(hours=1)))

--- a/app/status_monitor/status_web.py
+++ b/app/status_monitor/status_web.py
@@ -25,8 +25,11 @@ async def startup_event():
     )
     logging.info("Starting status-monitor server...")
     logging.info("Will report metrics to the cloud every hour")
-    scheduler.add_job(reporter.collect_metrics_for_cloud, "cron", hour="*", minute="1")
-    scheduler.add_job(reporter.report_metrics_to_cloud, "cron", hour="*", minute="2", jitter=120)
+    # Every hour, on the hour, collect metrics to send to the cloud.
+    scheduler.add_job(reporter.collect_metrics_for_cloud, "cron", hour="*", minute="0")
+    # Every hour, try to report collected metrics to the cloud. Run at 3 minutes past the hour, with a jitter of 120
+    # seconds, to avoid every edge-endpoint report hitting the server at the exact same time.
+    scheduler.add_job(reporter.report_metrics_to_cloud, "cron", hour="*", minute="3", jitter=120)
     scheduler.add_job(clear_old_activity_files, "interval", seconds=ONE_HOUR_IN_SECONDS)
     scheduler.start()
 

--- a/test/metrics/test_metric_reporting.py
+++ b/test/metrics/test_metric_reporting.py
@@ -82,6 +82,7 @@ class TestMetricsReporter:
 
         activity_metrics = payload["activity_metrics"]
         assert "last_activity_time" in activity_metrics
+        assert "log_hour" in activity_metrics
         assert "num_detectors_lifetime" in activity_metrics
         assert "num_detectors_active_1h" in activity_metrics
         assert "num_detectors_active_24h" in activity_metrics

--- a/test/metrics/test_metric_reporting.py
+++ b/test/metrics/test_metric_reporting.py
@@ -82,7 +82,7 @@ class TestMetricsReporter:
 
         activity_metrics = payload["activity_metrics"]
         assert "last_activity_time" in activity_metrics
-        assert "log_hour" in activity_metrics
+        assert "activity_hour" in activity_metrics
         assert "num_detectors_lifetime" in activity_metrics
         assert "num_detectors_active_1h" in activity_metrics
         assert "num_detectors_active_24h" in activity_metrics


### PR DESCRIPTION
When saving these metrics in the cloud, I'd like to have access to the hour they're reporting for in addition to the time they're sent. This PR adds that to the activity metrics. 

I also adjusted the cron job scheduling, I think before it was possible for the report job to run before the collect job. 