### PR TITLE
Enable Memory Optimizations for Helm Deployments

### DIFF
--- a/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
@@ -73,6 +73,8 @@ spec:
           value: /opt/models/pinamod
         - name: LOG_LEVEL
           value: {{ .Values.logLevel | quote }}
+        - name: LOAD_ALL_PIPELINES  # Load only the pipelines that are needed for edge inference.
+          value: "false"
         command:
           [
             "poetry", "run", "python3", "-m", "uvicorn", "serving.edge_inference_server.fastapi_server:app",


### PR DESCRIPTION
Enable memory optimization for helm deployments, previously only enabled for balena devices (`setup-ee` method).