### PR TITLE
Make OODD requests sequential

### DIFF
--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -150,7 +150,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
     elif app_state.edge_inference_manager.inference_is_available(detector_id=detector_id):
         # -- Edge-model Inference --
         logger.debug(f"Local inference is available for {detector_id=}. Running inference...")
-        results = await app_state.edge_inference_manager.run_inference(
+        results = app_state.edge_inference_manager.run_inference(
             detector_id=detector_id, image_bytes=image_bytes, content_type=content_type
         )
         ml_confidence = results["confidence"]

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 import shutil

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -44,7 +44,7 @@ def submit_image_for_inference(inference_client_url: str, image_bytes: bytes, co
             logger.error(f"Inference server returned an error: {response.status_code} - {response.text}")
             raise RuntimeError(f"Inference server error: {response.status_code} - {response.text}")
         return response.json()
-    except httpx.RequestError as e:
+    except requests.exceptions.RequestException as e:
         logger.error(f"Failed to connect to {inference_url}: {e}")
         raise RuntimeError("Failed to submit image for inference") from e
 

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -4,7 +4,6 @@ import shutil
 import time
 from typing import Optional
 
-import httpx
 import requests
 import yaml
 from cachetools import TTLCache, cached


### PR DESCRIPTION
After benchmarking, I determined that it's actually faster to run the primary and OODD inference requests sequentially, as opposed to in parallel with asyncio. OODD runs pretty quickly, so it seems that the setup time to gather the async results is more than what it takes to just run OODD after primary inference. This PR makes that change, to improve the edge-endpoint's framerate capability. 