### PR TITLE
Compute the DNS server at runtime to match the cluster

### DIFF
--- a/app/bin/launch-nginx.sh
+++ b/app/bin/launch-nginx.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Nginx won't refresh the IP address of the upstream endpoint without the "resolver" directive
+# but that requires the specific IP address of the DNS server, which can be different in different
+# clusters, so we determing that at runtime and edit nginx.conf before starting nginx.
+
+NAME_SERVER=$(awk '/^nameserver / {print $2; exit}' /etc/resolv.conf)
+echo "Using nameserver: $NAME_SERVER"
+
+sed "s/__NAME_SERVER__/$NAME_SERVER/" /opt/nginx/nginx.conf > /etc/nginx/nginx.conf
+
+exec nginx -g "daemon off;"

--- a/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
+++ b/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
@@ -38,7 +38,7 @@ http {
             # This is the default resolver for Kubernetes. We need to set it explicitly
             # and put the fallback server in a variable to get nginx to resolve it regularly.
             # This is important when going to an AWS ELB because the IPs change.
-            resolver 10.43.0.10 valid=30s;
+            resolver __NAME_SERVER__ valid=30s;
             {{- $parsedURL := .Values.upstreamEndpoint | urlParse }}
             set $upstreamEndpoint {{  index $parsedURL "scheme" }}://{{ index $parsedURL "host" }};
 

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -63,12 +63,12 @@ spec:
       - name: nginx
         image: *edgeEndpointImage
         imagePullPolicy: "{{ include "groundlight-edge-endpoint.edgeEndpointPullPolicy" . }}"
-        command: ["nginx", "-g", "daemon off;"]
+        command: ["/bin/bash", "-c", "./app/bin/launch-nginx.sh"]
         ports:
         - containerPort: 30101
         volumeMounts:
         - name: nginx-config-volume
-          mountPath: /etc/nginx/nginx.conf
+          mountPath: /opt/nginx/nginx.conf
           subPath: nginx.conf
         startupProbe:
           httpGet:


### PR DESCRIPTION
This makes it so that edge endpoint can run in various K8s clusters.