### PR TITLE
load-testing README updated to use helm commands

### DIFF
--- a/load-testing/README.md
+++ b/load-testing/README.md
@@ -29,7 +29,35 @@ command:
 
 Some trial and error will likely be necessary to figure out the ideal configuration.
 
-After setting these config options, you should run/re-run the [setup edge endpoint script](/deploy/bin/setup-ee.sh) to deploy with your new configuration. You can monitor the inference pod's logs to see when all of the workers have finished starting up (if the number of workers is high, this will likely be after the pod reports being ready). 
+After setting these config options, you should run/re-run the edge-endpoint installation command to deploy with your new configuration. 
+
+#### If using setup-ee.hm: 
+
+Run/re-run the [setup edge endpoint script](/deploy/bin/setup-ee.sh). You can monitor the inference pod's logs to see when all of the workers have finished starting up (if the number of workers is high, this will likely be after the pod reports being ready). 
+
+#### If using helm:
+
+Add the Groundlight Helm Repository:
+
+```
+helm repo add edge-endpoint https://code.groundlight.ai/edge-endpoint/
+helm repo update
+```
+
+Point Helm to the k3s cluster:
+
+```
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+```
+
+Reinstall the endpoint and set the configFile to the `edge-config.yaml` that you just modified:
+
+```
+# For an endpoint with default values:
+helm upgrade -i -n default edge-endpoint edge-endpoint/groundlight-edge-endpoint \
+  --set groundlightApiToken="${GROUNDLIGHT_API_TOKEN}" --set-file configFile=/path/to/your/edge-config.yaml
+```
+
 
 ### Configuring the load testing scripts
 


### PR DESCRIPTION
- Added helm commands to install edge-endpoint with new configurations: 
- Has all the steps to work for running in a different server than where the endpoint (resetting env variable)