### PR TITLE
Fixing edge metrics error message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && \
     sqlite3 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    curl -sSL https://install.python-poetry.org | python - && \
+    POETRY_HOME=${POETRY_HOME} curl -sSL https://install.python-poetry.org | python - && \
     curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     rm kubectl

--- a/app/status_monitor/static/status.html
+++ b/app/status_monitor/static/status.html
@@ -59,7 +59,7 @@
 
 <body>
     <header>
-        <h1>Groundlight Edge Endpoint Status</h1>
+        <h1>Groundlight Edge Endpoint Status Test 2</h1>
     </header>
     <div class="container">
         <div id="loading">Loading status...</div>
@@ -77,7 +77,7 @@
 
         <div class="section">
             <div class="section-title">Kubernetes Stats</div>
-            <pre id="k8s-stats"></pre>
+            <pre id="k3s-stats"></pre>
         </div>
     </div>
 

--- a/app/status_monitor/static/status.html
+++ b/app/status_monitor/static/status.html
@@ -59,7 +59,7 @@
 
 <body>
     <header>
-        <h1>Groundlight Edge Endpoint Status Test 2</h1>
+        <h1>Groundlight Edge Endpoint Status</h1>
     </header>
     <div class="container">
         <div id="loading">Loading status...</div>


### PR DESCRIPTION
There is an error message that always appears at the top of the edge metrics page, even if there is no error. This is caused by an incorrect ID in the html. 

![image](https://github.com/user-attachments/assets/c7e89f96-38cb-4125-b848-db56a77640e5)