### PR TITLE
Edge Only Mode - Edge Endpoint

### DIFF
--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -136,32 +136,11 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
             confidence=ml_confidence,
             confidence_threshold=confidence_threshold,
             is_done_processing=True,
-            query='', # We cannot fetch this, but do we really need it?
+            query='', # We cannot fetch this, but we don't need it, so we'll leave it blank
             patience_time=patience_time,
             rois=results["rois"],
             text=results["text"],
         )
-        is_confident_enough = ml_confidence >= confidence_threshold
-        if return_edge_prediction or is_confident_enough:  # Return the edge prediction
-            if return_edge_prediction:
-                logger.debug(f"Returning edge prediction without cloud escalation. {detector_id=}")
-            else:
-                logger.debug(f"Edge detector confidence sufficient. {detector_id=}")
-
-            image_query = create_iq(
-                detector_id=detector_id,
-                mode=ModeEnum.BINARY,  # URCap only supports binary
-                mode_configuration=None,  # None works for binary detectors
-                result_value=results["label"],
-                confidence=ml_confidence,
-                confidence_threshold=confidence_threshold,
-                is_done_processing=True,
-                query="",  # We cannot fetch this, but do we really need it?
-                patience_time=patience_time,
-                rois=results["rois"],
-                text=results["text"],
-            )
-
     else:
         # -- Edge-inference is not available --
         if return_edge_prediction:

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -2,13 +2,12 @@ import logging
 from typing import Literal, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
-from groundlight import Groundlight, ModeEnum
+from groundlight import ModeEnum
 from model import ImageQuery
 
 from app.core.app_state import (
     AppState,
     get_app_state,
-    get_groundlight_sdk_instance,
 )
 from app.core.utils import create_iq
 from app.metrics.iq_activity import record_activity_for_metrics
@@ -98,7 +97,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
             mode_configuration=None,  # None works for binary detectors
             result_value=results["label"],
             confidence=ml_confidence,
-            confidence_threshold=0.9, # an arbitrary value because this function requires it. The RPC server won't use it.
+            confidence_threshold=0.9,  # an arbitrary value because this function requires it. The RPC server won't use it.
             is_done_processing=True,
             query="",  # We cannot fetch this, but we don't need it, so we'll leave it blank
             patience_time=patience_time,

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -60,8 +60,8 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
     app_state: AppState = Depends(get_app_state),
 ):
     """
-    MODIFIED TO ONLY SUPPORT EDGE INFERENCE 
-    
+    MODIFIED TO ONLY SUPPORT EDGE INFERENCE
+
     Submit an image query for a given detector.
 
     This function attempts to run inference locally on the edge, if possible,
@@ -95,7 +95,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
     Raises:
         HTTPException: If there are issues with the request parameters or processing.
     """
-    
+
     await validate_query_params_for_edge(request)
 
     require_human_review = False
@@ -115,7 +115,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
             detail="Async requests are not supported on edge-only mode.",
         )
 
-    confidence_threshold = 0.9 # Set an arbitrary value since we cannot get one from the cloud. 
+    confidence_threshold = 0.9  # Set an arbitrary value since we cannot get one from the cloud.
 
     # for holding edge results if and when available
     results = None
@@ -130,13 +130,13 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
 
         return create_iq(
             detector_id=detector_id,
-            mode=ModeEnum.BINARY, # URCap only supports binary
-            mode_configuration=None, # None works for binary detectors
+            mode=ModeEnum.BINARY,  # URCap only supports binary
+            mode_configuration=None,  # None works for binary detectors
             result_value=results["label"],
             confidence=ml_confidence,
             confidence_threshold=confidence_threshold,
             is_done_processing=True,
-            query='', # We cannot fetch this, but do we really need it?
+            query="",  # We cannot fetch this, but do we really need it?
             patience_time=patience_time,
             rois=results["rois"],
             text=results["text"],
@@ -148,7 +148,7 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
             else:
                 logger.debug(f"Edge detector confidence sufficient. {detector_id=}")
 
-            image_query = create_iq(
+            create_iq(
                 detector_id=detector_id,
                 mode=ModeEnum.BINARY,  # URCap only supports binary
                 mode_configuration=None,  # None works for binary detectors

--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -87,6 +87,7 @@ def _get_groundlight_sdk_instance_internal(api_token: str):
     try:
         return Groundlight(api_token=api_token)
     except Exception:
+        # Handle the case where Groundlight is no longer responsive.
         logger.warning('Unable to instantiate Groundlight client.', exc_info=True)
         return None
 

--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -86,7 +86,8 @@ def get_detector_inference_configs(
 def _get_groundlight_sdk_instance_internal(api_token: str):
     try:
         return Groundlight(api_token=api_token)
-    except ApiTokenError:
+    except Exception:
+        logger.warning('Unable to instantiate Groundlight client.', exc_info=True)
         return None
 
 

--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -95,9 +95,7 @@ def get_groundlight_sdk_instance(request: Request):
     The SDK handles validation of the API token token itself, so there's no
     need to do that here.
     """
-    logger.info("running get_groundlight_sdk_instance")
     api_token = request.headers.get("x-api-token")
-    logger.info("get_groundlight_sdk_instance", api_token)
     return _get_groundlight_sdk_instance_internal(api_token)
 
 

--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 import cachetools
 import yaml
 from fastapi import Request
-from groundlight import Groundlight
+from groundlight import Groundlight, ApiTokenError
 from model import Detector
 
 from .configs import EdgeInferenceConfig, RootEdgeConfig
@@ -84,8 +84,10 @@ def get_detector_inference_configs(
 
 @lru_cache(maxsize=MAX_SDK_INSTANCES_CACHE_SIZE)
 def _get_groundlight_sdk_instance_internal(api_token: str):
-    return Groundlight(api_token=api_token)
-
+    try:
+        return Groundlight(api_token=api_token)
+    except ApiTokenError:
+        return None
 
 def get_groundlight_sdk_instance(request: Request):
     """
@@ -93,7 +95,9 @@ def get_groundlight_sdk_instance(request: Request):
     The SDK handles validation of the API token token itself, so there's no
     need to do that here.
     """
+    logger.info("running get_groundlight_sdk_instance")
     api_token = request.headers.get("x-api-token")
+    logger.info("get_groundlight_sdk_instance", api_token)
     return _get_groundlight_sdk_instance_internal(api_token)
 
 

--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 import cachetools
 import yaml
 from fastapi import Request
-from groundlight import ApiTokenError, Groundlight
+from groundlight import Groundlight
 from model import Detector
 
 from .configs import EdgeInferenceConfig, RootEdgeConfig
@@ -87,7 +87,7 @@ def _get_groundlight_sdk_instance_internal(api_token: str):
     try:
         return Groundlight(api_token=api_token)
     except Exception:
-        logger.warning('Unable to instantiate Groundlight client.', exc_info=True)
+        logger.warning("Unable to instantiate Groundlight client.", exc_info=True)
         return None
 
 

--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 import cachetools
 import yaml
 from fastapi import Request
-from groundlight import Groundlight, ApiTokenError
+from groundlight import ApiTokenError, Groundlight
 from model import Detector
 
 from .configs import EdgeInferenceConfig, RootEdgeConfig
@@ -88,6 +88,7 @@ def _get_groundlight_sdk_instance_internal(api_token: str):
         return Groundlight(api_token=api_token)
     except ApiTokenError:
         return None
+
 
 def get_groundlight_sdk_instance(request: Request):
     """

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -313,39 +313,18 @@ class EdgeInferenceManager:
 
         Returns True if a new model was downloaded and saved, False otherwise.
         """
-        logger.info(f"Checking if there are new models available for {detector_id}")
-
-        api_token = (
-            self.detector_inference_configs[detector_id].api_token
-            if self.detector_configured_for_edge_inference(detector_id)
-            else None
-        )
-
-        # fallback to env var if we don't have a token in the config
-        api_token = api_token or os.environ.get("GROUNDLIGHT_API_TOKEN", None)
-
-        edge_model_info, oodd_model_info = fetch_model_info(detector_id, api_token=api_token)
 
         edge_version, oodd_version = get_current_model_versions(self.MODEL_REPOSITORY, detector_id)
         primary_edge_model_dir = get_primary_edge_model_dir(self.MODEL_REPOSITORY, detector_id)
         oodd_model_dir = get_oodd_model_dir(self.MODEL_REPOSITORY, detector_id)
 
-        update_primary_model = should_update(edge_model_info, primary_edge_model_dir, edge_version)
-        update_oodd_model = should_update(oodd_model_info, oodd_model_dir, oodd_version)
+        update_primary_model = should_update(primary_edge_model_dir, edge_version)
+        update_oodd_model = should_update(oodd_model_dir, oodd_version)
 
         if not update_primary_model and not update_oodd_model:
             logger.debug(f"No new models available for {detector_id}")
             return False
 
-        logger.info(f"At least one new model is available for {detector_id}, saving models to repository.")
-        save_models_to_repository(
-            detector_id=detector_id,
-            edge_model_buffer=get_model_buffer(edge_model_info) if update_primary_model else None,
-            edge_model_info=edge_model_info if update_primary_model else None,
-            oodd_model_buffer=get_model_buffer(oodd_model_info) if update_oodd_model else None,
-            oodd_model_info=oodd_model_info if update_oodd_model else None,
-            repository_root=self.MODEL_REPOSITORY,
-        )
         return True
 
     def escalation_cooldown_complete(self, detector_id: str) -> bool:
@@ -492,31 +471,13 @@ def save_model_to_repository(
     )
 
 
-def should_update(model_info: ModelInfoBase, model_dir: str, version: Optional[int]) -> bool:
+def should_update(model_dir: str, version: Optional[int]) -> bool:
     """Determines if the model needs to be updated based on the received and current model info."""
     if version is None:
         logger.info(f"No current model version found in {model_dir}, updating model")
         return True
-
-    if isinstance(model_info, ModelInfoWithBinary):
-        edge_binary_ksuid = get_current_model_ksuid(model_dir, version)
-        if edge_binary_ksuid and model_info.model_binary_id == edge_binary_ksuid:
-            logger.info(
-                f"The edge binary in {model_dir} is the same as the cloud binary, so we don't need to update the model."
-            )
-            return False
     else:
-        current_pipeline_config = get_current_pipeline_config(model_dir, version)
-        if current_pipeline_config and current_pipeline_config == yaml.safe_load(model_info.pipeline_config):
-            logger.info(
-                f"The current pipeline_config in {model_dir} is the same as the received pipeline_config and we have no model binary, so we don't need to update the model."
-            )
-            return False
-
-    logger.info(
-        f"The model in {model_dir} needs to be updated, the current edge model is different from the cloud model."
-    )
-    return True
+        return False
 
 
 def get_current_model_versions(repository_root: str, detector_id: str) -> tuple[Optional[int], Optional[int]]:

--- a/deploy/bin/build-local-edge-endpoint-image.sh
+++ b/deploy/bin/build-local-edge-endpoint-image.sh
@@ -25,7 +25,7 @@ set -e
 
 cd "$(dirname "$0")"
 
-ECR_ACCOUNT=${ECR_ACCOUNT:-767397850842}
+ECR_ACCOUNT=${ECR_ACCOUNT:-557423365154}
 ECR_REGION=${ECR_REGION:-us-west-2}
 TAG=dev # In local mode, we always use the 'dev' tag
 EDGE_ENDPOINT_IMAGE=${EDGE_ENDPOINT_IMAGE:-edge-endpoint}  # v0.2.0 (fastapi inference server) compatible images

--- a/deploy/bin/build-push-edge-endpoint-image.sh
+++ b/deploy/bin/build-push-edge-endpoint-image.sh
@@ -13,7 +13,7 @@
 #
 # Note: Ensure you have the necessary AWS credentials and Docker installed.
 
-ECR_ACCOUNT=${ECR_ACCOUNT:-767397850842}
+ECR_ACCOUNT=${ECR_ACCOUNT:-557423365154}
 ECR_REGION=${ECR_REGION:-us-west-2}
 
 set -e

--- a/deploy/bin/refresh-ecr-login.sh
+++ b/deploy/bin/refresh-ecr-login.sh
@@ -5,7 +5,7 @@ set -e
 K=${KUBECTL_CMD:-"kubectl"}
 # No need to explicitly pick the namespace - this normally runs in its own namespace
 
-ECR_REGISTRY="767397850842.dkr.ecr.us-west-2.amazonaws.com"
+ECR_REGISTRY="557423365154.dkr.ecr.us-west-2.amazonaws.com"
 # TODO: We should probably put this in DNS
 
 ECR_PASSWORD=$(aws ecr get-login-password --region us-west-2)

--- a/deploy/bin/tag-edge-endpoint-image.sh
+++ b/deploy/bin/tag-edge-endpoint-image.sh
@@ -8,7 +8,7 @@
 set -e  # Exit immediately on error
 set -o pipefail
 
-ECR_ACCOUNT=${ECR_ACCOUNT:-767397850842}
+ECR_ACCOUNT=${ECR_ACCOUNT:-557423365154}
 ECR_REGION=${ECR_REGION:-us-west-2}
 
 # Ensure that you're in the same directory as this script before running it

--- a/deploy/k3s/edge_deployment/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment/edge_deployment.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: edge-endpoint-service-account
       initContainers:
         - name: database-prep
-          image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:${IMAGE_TAG}
+          image: &edgeEndpointImage 557423365154.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:dev
           imagePullPolicy: Always
           volumeMounts:
             - name: edge-endpoint-persistent-volume

--- a/deploy/k3s/inference_deployment/inference_deployment_template.yaml
+++ b/deploy/k3s/inference_deployment/inference_deployment_template.yaml
@@ -46,9 +46,7 @@ spec:
       - name: sync-pinamod
         image: amazon/aws-cli:latest
         # Sync models from S3 to the local hostmapped filesystem.
-        # Always exit with an exit code of 0, so that even if we are unable to get sync models, the
-        # rest of the pod can continue to function
-        command: ['sh', '-c', 'aws s3 sync s3://pinamod-artifacts-public/pinamod $PINAMOD_DIR --delete']
+        command: ['sh', '-c', 'mkdir -p $PINAMOD_DIR && aws s3 sync s3://pinamod-artifacts-lkq/pinamod $PINAMOD_DIR --delete']
         env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
@@ -65,9 +63,29 @@ spec:
         volumeMounts:
         - name: pina-models
           mountPath: /opt/models
+      - name: sync-edge-endpoint-state
+        image: amazon/aws-cli:latest
+        # Sync edge endpoint state from S3 to the local hostmapped filesystem.
+        command: ['sh', '-c', 'mkdir -p $EDGE_ENDPOINT_STATE_DIR && aws s3 sync s3://edge-endpoint-state/model-repo $EDGE_ENDPOINT_STATE_DIR --delete']
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws-credentials
+              key: aws_access_key_id
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws-credentials
+              key: aws_secret_access_key
+        - name: EDGE_ENDPOINT_STATE_DIR
+          value: /opt/groundlight/edge/serving/model-repo
+        volumeMounts:
+        - name: edge-endpoint-persistent-volume
+          mountPath: /opt/groundlight/edge/serving/model-repo        
       containers:
       - name: inference-server
-        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/gl-edge-inference:latest
+        image: 557423365154.dkr.ecr.us-west-2.amazonaws.com/gl-edge-inference:dev
         imagePullPolicy: Always
         env:
         - name: MODEL_REPOSITORY
@@ -77,7 +95,7 @@ spec:
         - name: PINAMOD_DIR
           value: /opt/models/pinamod
         - name: LOAD_ALL_PIPELINES  # Load only the pipelines that are needed for edge inference.
-          value: "false"
+          value: "true"
         command:
           [
             "poetry", "run", "python3", "-m", "uvicorn", "serving.edge_inference_server.fastapi_server:app",

--- a/deploy/k3s/inference_deployment/inference_deployment_template.yaml
+++ b/deploy/k3s/inference_deployment/inference_deployment_template.yaml
@@ -55,17 +55,18 @@ spec:
             secretKeyRef:
               name: aws-credentials
               key: aws_access_key_id
+              optional: true  # allow the container to come up even if credentials have expired
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
               name: aws-credentials
               key: aws_secret_access_key
+              optional: true # allow the container to come up even if credentials have expired
         - name: PINAMOD_DIR
           value: /opt/models/pinamod
         volumeMounts:
         - name: pina-models
           mountPath: /opt/models
-
       containers:
       - name: inference-server
         image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/gl-edge-inference:latest

--- a/deploy/k3s/inference_deployment/inference_deployment_template.yaml
+++ b/deploy/k3s/inference_deployment/inference_deployment_template.yaml
@@ -48,20 +48,18 @@ spec:
         # Sync models from S3 to the local hostmapped filesystem.
         # Always exit with an exit code of 0, so that even if we are unable to get sync models, the
         # rest of the pod can continue to function
-        command: ['sh', '-c', 'aws s3 sync s3://pinamod-artifacts-public/pinamod $PINAMOD_DIR --delete || true']
+        command: ['sh', '-c', 'aws s3 sync s3://pinamod-artifacts-public/pinamod $PINAMOD_DIR --delete']
         env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
               name: aws-credentials
               key: aws_access_key_id
-              optional: true  # allow the container to come up even if credentials have expired
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
               name: aws-credentials
               key: aws_secret_access_key
-              optional: true # allow the container to come up even if credentials have expired
         - name: PINAMOD_DIR
           value: /opt/models/pinamod
         volumeMounts:

--- a/deploy/k3s/inference_deployment/inference_deployment_template.yaml
+++ b/deploy/k3s/inference_deployment/inference_deployment_template.yaml
@@ -46,7 +46,9 @@ spec:
       - name: sync-pinamod
         image: amazon/aws-cli:latest
         # Sync models from S3 to the local hostmapped filesystem.
-        command: ['sh', '-c', 'aws s3 sync s3://pinamod-artifacts-public/pinamod $PINAMOD_DIR --delete']
+        # Always exit with an exit code of 0, so that even if we are unable to get sync models, the
+        # rest of the pod can continue to function
+        command: ['sh', '-c', 'aws s3 sync s3://pinamod-artifacts-public/pinamod $PINAMOD_DIR --delete || true']
         env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:

--- a/deploy/k3s/inference_deployment/warmup_inference_model.yaml
+++ b/deploy/k3s/inference_deployment/warmup_inference_model.yaml
@@ -10,12 +10,12 @@ spec:
       - name: registry-credentials
       containers:
       - name: image-puller
-        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/gl-edge-inference:latest
+        image: 557423365154.dkr.ecr.us-west-2.amazonaws.com/gl-edge-inference:dev
         command: ["echo", "Successfully pulled image to warm cache"]
       - name: sync-pinamod
         image: amazon/aws-cli:latest
         # Sync models from S3 to the local hostmapped filesystem.
-        command: ['sh', '-c', 'aws s3 sync s3://pinamod-artifacts-public/pinamod $PINAMOD_DIR --delete']
+        command: ['sh', '-c', 'aws s3 sync s3://pinamod-artifacts-lkq/pinamod $PINAMOD_DIR --delete']
         env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:

--- a/deploy/k3s/refresh_creds.yaml
+++ b/deploy/k3s/refresh_creds.yaml
@@ -18,7 +18,7 @@ spec:
             - name: registry-credentials
           containers:
           - name: ecr
-            image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:${IMAGE_TAG}
+            image: 557423365154.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:dev
             command: [
               "/bin/sh",
               "-c",


### PR DESCRIPTION
A modified version of the Edge Endpoint that only supports edge inference. We won't actually merge these changes, but rather keep them in their own branch and deploy from here as needed.

Deploy it normally with an API token and some configured detectors.

After initial deployment, you can delete the API token and reboot and it will continue to serve edge inferences for the configured detectors.

Related PR: https://github.com/positronix-ai/rpc-server/pull/51