### PR TITLE
Give sync-pinamod container IfNotPresent image pull policy

### DIFF
--- a/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
@@ -49,6 +49,7 @@ spec:
       # TODO: refactor to share code between the Job and the initContainer in the Deployment
       - name: sync-pinamod
         image: amazon/aws-cli:latest
+        imagePullPolicy: IfNotPresent
         # Sync models from S3 to the local hostmapped filesystem.
         command: ['sh', '-c', 'aws s3 sync s3://pinamod-artifacts-public/pinamod $PINAMOD_DIR --delete']
         env:

--- a/deploy/k3s/inference_deployment/inference_deployment_template.yaml
+++ b/deploy/k3s/inference_deployment/inference_deployment_template.yaml
@@ -45,6 +45,7 @@ spec:
       # TODO: refactor to share code between the Job and the initContainer in the Deployment
       - name: sync-pinamod
         image: amazon/aws-cli:latest
+        imagePullPolicy: IfNotPresent
         # Sync models from S3 to the local hostmapped filesystem.
         command: ['sh', '-c', 'aws s3 sync s3://pinamod-artifacts-public/pinamod $PINAMOD_DIR --delete']
         env:


### PR DESCRIPTION
To avoid pulling AWS CLI image if already present, for network requirements reasons. Changing both setup-ee and helm version for consistency.