### PR TITLE
Update namespace used for kubernetes stats

### DIFF
--- a/app/metrics/system_metrics.py
+++ b/app/metrics/system_metrics.py
@@ -40,7 +40,12 @@ def get_namespace() -> str:
     DEPLOYMENT_NAMESPACE environment variable (setup-ee.sh method). If neither exist, default to
     the namespace "edge"
     """
-    namespace = os.getenv("NAMESPACE", os.getenv("DEPLOYMENT_NAMESPACE", "edge"))
+    namespace = os.getenv("NAMESPACE", os.getenv("DEPLOYMENT_NAMESPACE"))
+
+    if namespace is None:
+        logger.error("Neither NAMESPACE nor DEPLOYMENT_NAMESPACE are set, using default namespace 'edge'")
+        namespace = "edge"
+
     return namespace
 
 

--- a/app/metrics/system_metrics.py
+++ b/app/metrics/system_metrics.py
@@ -35,9 +35,9 @@ def get_inference_flavor() -> str:
 def get_namespace() -> str:
     """
     Get the namespace of the EE.
-    
+
     Use the NAMESPACE environment variable if it exists (helm setup method), otherwise use the
-    DEPLOYMENT_NAMESPACE environment variable (setup-ee.sh method). If neither exist, default to 
+    DEPLOYMENT_NAMESPACE environment variable (setup-ee.sh method). If neither exist, default to
     the namespace "edge"
     """
     namespace = os.getenv("NAMESPACE", os.getenv("DEPLOYMENT_NAMESPACE", "edge"))

--- a/app/metrics/system_metrics.py
+++ b/app/metrics/system_metrics.py
@@ -32,11 +32,24 @@ def get_inference_flavor() -> str:
     return inference_flavor
 
 
+def get_namespace() -> str:
+    """
+    Get the namespace of the EE.
+    
+    Use the NAMESPACE environment variable if it exists (helm setup method), otherwise use the
+    DEPLOYMENT_NAMESPACE environment variable (setup-ee.sh method). If neither exist, default to 
+    the namespace "edge"
+    """
+    namespace = os.getenv("NAMESPACE", os.getenv("DEPLOYMENT_NAMESPACE", "edge"))
+    return namespace
+
+
 def get_deployments() -> str:
     config.load_incluster_config()
     v1_apps = client.AppsV1Api()
 
-    deployments = v1_apps.list_namespaced_deployment(namespace=os.getenv("NAMESPACE", "edge"))
+    namespace = get_namespace()
+    deployments = v1_apps.list_namespaced_deployment(namespace=namespace)
 
     deployment_names = []
     for dep in deployments.items:
@@ -47,7 +60,8 @@ def get_deployments() -> str:
 def get_pods() -> str:
     config.load_incluster_config()
     v1_core = client.CoreV1Api()
-    pods = v1_core.list_namespaced_pod(namespace=os.getenv("NAMESPACE", "edge"))
+    namespace = get_namespace()
+    pods = v1_core.list_namespaced_pod(namespace=namespace)
 
     # Convert the pods dict to a JSON string to prevent opensearch from indexing all
     # the individual pod fields
@@ -57,7 +71,8 @@ def get_pods() -> str:
 def get_container_images() -> str:
     config.load_incluster_config()
     v1_core = client.CoreV1Api()
-    pods = v1_core.list_namespaced_pod(namespace=os.getenv("NAMESPACE", "edge"))
+    namespace = get_namespace()
+    pods = v1_core.list_namespaced_pod(namespace=namespace)
 
     containers = {}
     for pod in pods.items:

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -155,6 +155,8 @@ spec:
               name: groundlight-api-token
               key: GROUNDLIGHT_API_TOKEN
               optional: true
+        - name: NAMESPACE
+          value: "{{ .Values.namespace }}"
         - name: INFERENCE_FLAVOR
           value: "{{ .Values.inferenceFlavor }}"
         volumeMounts:

--- a/deploy/k3s/edge_deployment/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment/edge_deployment.yaml
@@ -114,6 +114,8 @@ spec:
                   name: groundlight-api-token
                   key: GROUNDLIGHT_API_TOKEN
                   optional: true
+            - name: DEPLOYMENT_NAMESPACE
+              value: ${DEPLOYMENT_NAMESPACE}
           volumeMounts:
             - name: edge-config-volume
               mountPath: /etc/groundlight/edge-config


### PR DESCRIPTION
We have seen some 403 errors in opensearch logs for edge metrics, as well as on the status page. I determined that those errors only occurred on edge-endpoints set up with `setup-ee`, since the namespace used is different. 

I manually verified that I don't see 403 errors (or other errors) when accessing the status page for an edge endpoint deployed with helm or one deployed with `setup-ee` after these changes. 