### PR TITLE
Don't erase container images in the K3s pre-load directory

### DIFF
--- a/deploy/balena-k3s/server/server.sh
+++ b/deploy/balena-k3s/server/server.sh
@@ -6,9 +6,15 @@
 set -eux
 
 # Kill any existing k3s server processes and reset them -
-# WARNING: this will remove all cluster data such as running pods, services, etc.
+# WARNING: this will remove all cluster data such as running pods, services, etc., except for
+# pre-load images
 pkill -f k3s || true
-rm -rf /var/lib/rancher/k3s/*
+if [ -d /var/lib/rancher/k3s/agent ]; then
+    find /var/lib/rancher/k3s/agent -mindepth 1 -maxdepth 1 ! -path /var/lib/rancher/k3s/agent/images -exec rm -rf {} +
+fi
+if [ -d /var/lib/rancher/k3s ]; then
+    find /var/lib/rancher/k3s -mindepth 1 -maxdepth 1 ! -path /var/lib/rancher/k3s/agent -exec rm -rf {} +
+fi
 sleep 2
 
 # Whether to enable GPU support on K3s. Defaults to false.


### PR DESCRIPTION
This lets us load images onto machines so they don't need to be pulled from Docker Hub. More automation coming.