### PR TITLE
Fix confidence threshold boolean logic bug

### DIFF
--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -152,7 +152,9 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
     # Schedule a background task to refresh the detector metadata if it's too old
     background_tasks.add_task(refresh_detector_metadata_if_needed, detector_id, gl)
 
-    confidence_threshold = confidence_threshold or detector_metadata.confidence_threshold
+    confidence_threshold = (
+        confidence_threshold if confidence_threshold is not None else detector_metadata.confidence_threshold
+    )
 
     # For holding edge results if and when available
     results = None


### PR DESCRIPTION
The inputted confidence threshold is permitted to be 0 but in that case the edge would always use the detector's confidence threshold, since 0.0 evaluates to False. Instead the expression should explicitly check for `None`.