### PR TITLE
Fixed SNI missing in nginx proxy

### DIFF
--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -38,6 +38,16 @@ http {
         location @fallback {
             # Fallback to the cloud API server
             proxy_pass https://api.groundlight.ai;
+
+            # Ensure correct SNI/Host to upstream
+            proxy_ssl_server_name on;                 # send SNI
+            proxy_ssl_name api.groundlight.ai;        # (explicit; optional if using $proxy_host)
+            proxy_set_header Host $proxy_host;        # or: proxy_set_header Host api.groundlight.ai;
+
+            # Forward standard headers
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $host;
         }
 
     }


### PR DESCRIPTION
This PR fixed a bug in the nginx proxy where when deploying edge-endpoint behind a firewall requests will get blocked due to SNI not being carried over. As some firewall requires client to provide SNI information, requests will get blocked even if the allowlist does include the domain names.