### PR TITLE
Switch to bitnamilegacy kubectl image as a temporary fix for upcoming deprecation

### DIFF
--- a/deploy/helm/groundlight-edge-endpoint/templates/_ecr-creds-podspec.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/_ecr-creds-podspec.yaml
@@ -25,7 +25,7 @@ containers:
         subPath: init-aws-access-retrieve.sh
 
   - name: kubectl
-    image: bitnami/kubectl:latest
+    image: bitnamilegacy/kubectl:latest
     command:
       - /bin/sh
       - /app/init-aws-access-apply.sh

--- a/deploy/helm/groundlight-edge-endpoint/templates/cleanup-old-jobs.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/cleanup-old-jobs.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: job-cleanup-sa  # Ensure permissions to delete Jobs
       containers:
         - name: kubectl
-          image: bitnami/kubectl:latest
+          image: bitnamilegacy/kubectl:latest
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
Per [this announcement](https://github.com/bitnami/containers/issues/83267), Bitnami is deleting their public catalog of docker images and transitioning to providing "Bitnami secure images". 

We use the `kubectl` image from bitnami, which will no longer be available from the public catalog on 9/29 (and also for a temporary brownout from 9/17 to 9/19). This PR switches us to pull from `bitnamilegacy/kubectl` instead ([link here](https://hub.docker.com/r/bitnamilegacy/kubectl)), which is a backup of the legacy images. 

This legacy catalog may be removed in the future, so we should switch to either self-hosting or using their secure image (secure kubectl image [can be found here](https://hub.docker.com/r/bitnamisecure/kubectl)). 