### PR TITLE
Fix Inference Pod Failures on Slow Networks

### DIFF
--- a/deploy/bin/wait-for-warmup.sh
+++ b/deploy/bin/wait-for-warmup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+
+echo "Checking for warmup-inference-model job..."
+if kubectl get job warmup-inference-model -n "$NS" &>/dev/null; then
+    echo "Waiting for warmup-inference-model to complete..."
+    kubectl wait --for=condition=complete job/warmup-inference-model -n "$NS" --timeout=1800s \
+        || echo "Wait timed out or job failed, proceeding anyway."
+else
+    echo "Warmup job not found, proceeding."
+fi

--- a/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
@@ -48,20 +48,9 @@ spec:
 
       initContainers:
       - name: wait-for-warmup
-        image: bitnamilegacy/kubectl:latest
-        imagePullPolicy: IfNotPresent
-        command:
-          - sh
-          - -c
-          - |
-            NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
-            echo "Checking for warmup-inference-model job..."
-            if kubectl get job warmup-inference-model -n $NS &>/dev/null; then
-              echo "Waiting for warmup-inference-model to complete..."
-              kubectl wait --for=condition=complete job/warmup-inference-model -n $NS --timeout=1800s || echo "Wait timed out or job failed, proceeding anyway."
-            else
-              echo "Warmup job not found, proceeding."
-            fi
+        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:{{ include "groundlight-edge-endpoint.edgeEndpointTag" . }}
+        imagePullPolicy: "{{ include "groundlight-edge-endpoint.edgeEndpointPullPolicy" . }}"
+        command: ["/bin/bash", "/groundlight-edge/deploy/bin/wait-for-warmup.sh"]
 
       # NOTE: the sync-pinamod container is duplicated in the warmup_inference_model.yaml Job
       # TODO: refactor to share code between the Job and the initContainer in the Deployment

--- a/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
@@ -37,6 +37,7 @@ spec:
 {{ if eq .Values.inferenceFlavor "gpu" }}
       runtimeClassName: nvidia  # Required for GPU use in k3s
 {{- end }}
+      serviceAccountName: edge-endpoint-service-account
       imagePullSecrets:
       - name: registry-credentials
       strategy:
@@ -46,6 +47,22 @@ spec:
           maxUnavailable: 0  # Aim for no downtime during rollout
 
       initContainers:
+      - name: wait-for-warmup
+        image: bitnamilegacy/kubectl:latest
+        imagePullPolicy: IfNotPresent
+        command:
+          - sh
+          - -c
+          - |
+            NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+            echo "Checking for warmup-inference-model job..."
+            if kubectl get job warmup-inference-model -n $NS &>/dev/null; then
+              echo "Waiting for warmup-inference-model to complete..."
+              kubectl wait --for=condition=complete job/warmup-inference-model -n $NS --timeout=1800s || echo "Wait timed out or job failed, proceeding anyway."
+            else
+              echo "Warmup job not found, proceeding."
+            fi
+
       # NOTE: the sync-pinamod container is duplicated in the warmup_inference_model.yaml Job
       # TODO: refactor to share code between the Job and the initContainer in the Deployment
       - name: sync-pinamod

--- a/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
@@ -116,7 +116,7 @@ spec:
             port: 8000
           initialDelaySeconds: 10
           periodSeconds: 10
-          failureThreshold: 120  # Wait for up to 20 min
+          failureThreshold: 270  # Wait for up to 45 min
         readinessProbe:
           httpGet:
             path: /health/ready  # Checks if the server is ready to serve requests

--- a/deploy/helm/groundlight-edge-endpoint/templates/_ecr-creds-podspec.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/_ecr-creds-podspec.yaml
@@ -25,8 +25,7 @@ containers:
         subPath: init-aws-access-retrieve.sh
 
   - name: kubectl
-    image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:{{ include "groundlight-edge-endpoint.edgeEndpointTag" . }}
-    imagePullPolicy: "{{ include "groundlight-edge-endpoint.edgeEndpointPullPolicy" . }}"
+    image: bitnami/kubectl:latest
     command:
       - /bin/sh
       - /app/init-aws-access-apply.sh

--- a/deploy/helm/groundlight-edge-endpoint/templates/_ecr-creds-podspec.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/_ecr-creds-podspec.yaml
@@ -25,7 +25,8 @@ containers:
         subPath: init-aws-access-retrieve.sh
 
   - name: kubectl
-    image: bitnamilegacy/kubectl:latest
+    image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:{{ include "groundlight-edge-endpoint.edgeEndpointTag" . }}
+    imagePullPolicy: "{{ include "groundlight-edge-endpoint.edgeEndpointPullPolicy" . }}"
     command:
       - /bin/sh
       - /app/init-aws-access-apply.sh

--- a/deploy/helm/groundlight-edge-endpoint/templates/cleanup-old-jobs.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/cleanup-old-jobs.yaml
@@ -17,7 +17,8 @@ spec:
       serviceAccountName: job-cleanup-sa  # Ensure permissions to delete Jobs
       containers:
         - name: kubectl
-          image: bitnamilegacy/kubectl:latest
+          image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:{{ include "groundlight-edge-endpoint.edgeEndpointTag" . }}
+          imagePullPolicy: "{{ include "groundlight-edge-endpoint.edgeEndpointPullPolicy" . }}"
           command:
             - /bin/sh
             - -c

--- a/deploy/helm/groundlight-edge-endpoint/templates/cleanup-old-jobs.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/cleanup-old-jobs.yaml
@@ -17,8 +17,7 @@ spec:
       serviceAccountName: job-cleanup-sa  # Ensure permissions to delete Jobs
       containers:
         - name: kubectl
-          image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:{{ include "groundlight-edge-endpoint.edgeEndpointTag" . }}
-          imagePullPolicy: "{{ include "groundlight-edge-endpoint.edgeEndpointPullPolicy" . }}"
+          image: bitnami/kubectl:latest
           command:
             - /bin/sh
             - -c

--- a/deploy/helm/groundlight-edge-endpoint/templates/service-account.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/service-account.yaml
@@ -44,6 +44,10 @@ rules:
   resources: ["secrets"]
   # Needed to refresh ECR credentials
   verbs: ["create", "delete", "get", "patch"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  # Needed by inference pod init containers to wait for warmup-inference-model Job completion
+  verbs: ["get", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/helm/groundlight-edge-endpoint/templates/service-account.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/service-account.yaml
@@ -47,7 +47,7 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   # Needed by inference pod init containers to wait for warmup-inference-model Job completion
-  verbs: ["get", "watch"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/k3s/inference_deployment/inference_deployment_template.yaml
+++ b/deploy/k3s/inference_deployment/inference_deployment_template.yaml
@@ -44,20 +44,9 @@ spec:
 
       initContainers:
       - name: wait-for-warmup
-        image: bitnamilegacy/kubectl:latest
+        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:${IMAGE_TAG}
         imagePullPolicy: IfNotPresent
-        command:
-          - sh
-          - -c
-          - |
-            NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
-            echo "Checking for warmup-inference-model job..."
-            if kubectl get job warmup-inference-model -n $NS &>/dev/null; then
-              echo "Waiting for warmup-inference-model to complete..."
-              kubectl wait --for=condition=complete job/warmup-inference-model -n $NS --timeout=1800s || echo "Wait timed out or job failed, proceeding anyway."
-            else
-              echo "Warmup job not found, proceeding."
-            fi
+        command: ["/bin/bash", "/groundlight-edge/deploy/bin/wait-for-warmup.sh"]
 
       # NOTE: the sync-pinamod container is duplicated in the warmup_inference_model.yaml Job
       # TODO: refactor to share code between the Job and the initContainer in the Deployment

--- a/deploy/k3s/inference_deployment/inference_deployment_template.yaml
+++ b/deploy/k3s/inference_deployment/inference_deployment_template.yaml
@@ -33,6 +33,7 @@ spec:
     spec:
       hostPID: true  # Allows pynvml to match this process's PID against nvidia-smi PIDs for accurate per-pod VRAM reporting
       runtimeClassName: nvidia  # Required for GPU use in k3s
+      serviceAccountName: edge-endpoint-service-account
       imagePullSecrets:
       - name: registry-credentials
       strategy:
@@ -42,6 +43,22 @@ spec:
           maxUnavailable: 0  # Aim for no downtime during rollout
 
       initContainers:
+      - name: wait-for-warmup
+        image: bitnamilegacy/kubectl:latest
+        imagePullPolicy: IfNotPresent
+        command:
+          - sh
+          - -c
+          - |
+            NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+            echo "Checking for warmup-inference-model job..."
+            if kubectl get job warmup-inference-model -n $NS &>/dev/null; then
+              echo "Waiting for warmup-inference-model to complete..."
+              kubectl wait --for=condition=complete job/warmup-inference-model -n $NS --timeout=1800s || echo "Wait timed out or job failed, proceeding anyway."
+            else
+              echo "Warmup job not found, proceeding."
+            fi
+
       # NOTE: the sync-pinamod container is duplicated in the warmup_inference_model.yaml Job
       # TODO: refactor to share code between the Job and the initContainer in the Deployment
       - name: sync-pinamod

--- a/deploy/k3s/inference_deployment/inference_deployment_template.yaml
+++ b/deploy/k3s/inference_deployment/inference_deployment_template.yaml
@@ -108,6 +108,8 @@ spec:
           value: /opt/models/pinamod
         - name: LOAD_ALL_PIPELINES  # Load only the pipelines that are needed for edge inference.
           value: "false"
+        - name: INFERENCE_FLAVOR
+          value: "gpu"
         - name: WORKERS  # Number of uvicorn workers for the inference server
           value: "1"
         volumeMounts:
@@ -125,7 +127,7 @@ spec:
             port: 8000
           initialDelaySeconds: 10
           periodSeconds: 10
-          failureThreshold: 120  # Wait for up to 20 min
+          failureThreshold: 270  # Wait for up to 45 min
         readinessProbe:
           httpGet:
             path: /health/ready  # Checks if the server is ready to serve requests


### PR DESCRIPTION
### Summary

- **Warmup-first coordination**: Added a `wait-for-warmup` init container to inference deployments (both Helm and K3s templates) that waits for the `warmup-inference-model` Job to complete before running `sync-pinamod`. This eliminates a race condition where multiple inference pods concurrently running `aws s3 sync --delete` on a shared hostPath volume would delete each other's temporary files, causing rename failures and crash loops.
- **RBAC update**: Granted `get`, `list`, `watch` on `batch/jobs` to the existing service account so the `kubectl wait` in the init container can function.
- **Startup probe timeout increase**: Bumped `startupProbe.failureThreshold` from 120 (20 min) to 270 (45 min) to accommodate slow `timm`/HuggingFace backbone model downloads on constrained networks.
- **Missing `INFERENCE_FLAVOR` env var**: Added `INFERENCE_FLAVOR=gpu` to the K3s inference deployment template, which was present in the Helm template but missing from K3s, causing inference pods to not utilize the GPU.

### Test plan

- [x] Tested on a G4 EC2 instance with network throttling (~2 MiB/s) to verify warmup completes before inference pods start syncing. The process took around 1 hour to for `warmup-inference-model` to download the inference image (3.7GB) and run `sync-pinamod` (2.6GB)
- [x] Tested working on new inference pod rollouts (after cold boot)
- [x] Verified startup probe does not prematurely kill pods during long timm downloads