### PR TITLE
Stamp primary+OODD MLB KSUIDs into edge_result metadata

### DIFF
--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -197,6 +197,8 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
                 patience_time=patience_time,
                 rois=results["rois"],
                 text=results["text"],
+                mlb_key=results.get("mlb_key"),
+                oodd_mlb_key=results.get("oodd_mlb_key"),
             )
 
             # Skip cloud operations if escalation is disabled

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -324,6 +324,28 @@ class EdgeInferenceManager:
 
         output_dict = get_inference_result(response, oodd_response, mode)
 
+        # Stamp the currently-loaded MLB KSUIDs into the result so that
+        # edge_result.mlb_key (and oodd_mlb_key when applicable) is persisted
+        # on Posicheck.metadata.edge_result for cloud-vs-edge debugging.
+        # Wrapped in try/except: stamping is purely diagnostic and must never
+        # take down inference if the model_id.txt is missing or unreadable.
+        try:
+            primary_version = get_current_model_version(self.MODEL_REPOSITORY, detector_id)
+            if primary_version is not None:
+                primary_dir = get_primary_edge_model_dir(self.MODEL_REPOSITORY, detector_id)
+                mlb_key = get_current_model_ksuid(primary_dir, primary_version)
+                if mlb_key is not None:
+                    output_dict["mlb_key"] = mlb_key
+            if self.separate_oodd_inference and oodd_response is not None:
+                oodd_version = get_current_model_version(self.MODEL_REPOSITORY, detector_id, is_oodd=True)
+                if oodd_version is not None:
+                    oodd_dir = get_oodd_model_dir(self.MODEL_REPOSITORY, detector_id)
+                    oodd_mlb_key = get_current_model_ksuid(oodd_dir, oodd_version)
+                    if oodd_mlb_key is not None:
+                        output_dict["oodd_mlb_key"] = oodd_mlb_key
+        except Exception as e:
+            logger.warning(f"Could not stamp MLB key into edge_result: {e}")
+
         elapsed_ms = (time.perf_counter() - start_time) * 1000
         self.speedmon.update(detector_id, elapsed_ms)
         fps = self.speedmon.average_fps(detector_id)

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -294,10 +294,14 @@ class EdgeInferenceManager:
             content_type: The content type of the image
         Returns:
             Dictionary of inference results with keys:
-                - "score": float
-                - "confidence": float
-                - "probability": float
+                - "confidence": float — adjusted confidence when OODD is enabled, primary otherwise
                 - "label": int
+                - "rois": list[dict] | None — when the pipeline produces ROIs
+                - "text": str | None — when the pipeline produces a text prediction
+                - "raw_primary_confidence": float — only when OODD is enabled
+                - "raw_oodd_prediction": dict — only when OODD is enabled
+                - "mlb_key": str — primary MLB KSUID, when model_id.txt is readable
+                - "oodd_mlb_key": str — OODD MLB KSUID, when OODD is enabled and readable
         """
         logger.info(f"Submitting image to edge inference service. {detector_id=}")
         start_time = time.perf_counter()

--- a/app/core/edge_inference.py
+++ b/app/core/edge_inference.py
@@ -331,18 +331,14 @@ class EdgeInferenceManager:
         # take down inference if the model_id.txt is missing or unreadable.
         try:
             primary_version = get_current_model_version(self.MODEL_REPOSITORY, detector_id)
-            if primary_version is not None:
-                primary_dir = get_primary_edge_model_dir(self.MODEL_REPOSITORY, detector_id)
-                mlb_key = get_current_model_ksuid(primary_dir, primary_version)
-                if mlb_key is not None:
-                    output_dict["mlb_key"] = mlb_key
+            primary_dir = get_primary_edge_model_dir(self.MODEL_REPOSITORY, detector_id)
+            if mlb_key := get_current_model_ksuid(primary_dir, primary_version):
+                output_dict["mlb_key"] = mlb_key
             if self.separate_oodd_inference and oodd_response is not None:
                 oodd_version = get_current_model_version(self.MODEL_REPOSITORY, detector_id, is_oodd=True)
-                if oodd_version is not None:
-                    oodd_dir = get_oodd_model_dir(self.MODEL_REPOSITORY, detector_id)
-                    oodd_mlb_key = get_current_model_ksuid(oodd_dir, oodd_version)
-                    if oodd_mlb_key is not None:
-                        output_dict["oodd_mlb_key"] = oodd_mlb_key
+                oodd_dir = get_oodd_model_dir(self.MODEL_REPOSITORY, detector_id)
+                if oodd_mlb_key := get_current_model_ksuid(oodd_dir, oodd_version):
+                    output_dict["oodd_mlb_key"] = oodd_mlb_key
         except Exception as e:
             logger.warning(f"Could not stamp MLB key into edge_result: {e}")
 

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -197,6 +197,8 @@ def generate_metadata_dict(results: dict[str, Any] | None, is_edge_audit: bool =
     Includes `"is_edge_audit": True` if it is an edge audit.
     Includes `"edge_result": results` if including the results would not push the metadata over the size limit. If they
         would, includes the results without the ROIs if the resulting metadata does not exceed the limit.
+    Includes `"mlb_key": "mlb_value"` if the results include a "mlb_key" field. So we can identify the MLB key used for inference.
+    Includes `"oodd_mlb_key": "oodd_mlb_value"` if the results include a "oodd_mlb_key" field. So we can identify the OODD MLB key used for inference.
     """
     metadata_dict = {}
 

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -197,8 +197,9 @@ def generate_metadata_dict(results: dict[str, Any] | None, is_edge_audit: bool =
     Includes `"is_edge_audit": True` if it is an edge audit.
     Includes `"edge_result": results` if including the results would not push the metadata over the size limit. If they
         would, includes the results without the ROIs if the resulting metadata does not exceed the limit.
-    Includes `"mlb_key": "mlb_value"` if the results include a "mlb_key" field. So we can identify the MLB key used for inference.
-    Includes `"oodd_mlb_key": "oodd_mlb_value"` if the results include a "oodd_mlb_key" field. So we can identify the OODD MLB key used for inference.
+    The `results` dict may carry `"mlb_key"` and `"oodd_mlb_key"` identifying the primary/OODD ML binary
+        used for inference; those are passed through as part of `edge_result` with no special handling,
+        so the cloud sees them at `metadata["edge_result"]["mlb_key"]` / `["oodd_mlb_key"]`.
     """
     metadata_dict = {}
 

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -49,6 +49,8 @@ def create_iq(  # noqa: PLR0913
     patience_time: float | None = None,
     rois: list[ROI] | None = None,
     text: str | None = None,
+    mlb_key: str | None = None,
+    oodd_mlb_key: str | None = None,
 ) -> ImageQuery:
     """
     Creates an ImageQuery object for the appropriate detector with the given result.
@@ -63,6 +65,10 @@ def create_iq(  # noqa: PLR0913
     :param patience_time: The acceptable time to wait for a result.
     :param rois: The ROIs associated with the prediction, if applicable.
     :param text: The text associated with the prediction, if applicable.
+    :param mlb_key: KSUID of the primary MLB used for local inference. Stamped onto `metadata.mlb_key`
+        so callers of local/no-cloud detectors can identify which binary produced the result without
+        needing to escalate and re-fetch.
+    :param oodd_mlb_key: KSUID of the OODD MLB, same purpose as `mlb_key`.
 
     :return: The created ImageQuery.
     """
@@ -70,8 +76,14 @@ def create_iq(  # noqa: PLR0913
         patience_time = constants.DEFAULT_PATIENCE_TIME
     result_type, result = _mode_to_result_and_type(mode, mode_configuration, confidence, result_value)
 
+    metadata: dict[str, Any] = {"is_from_edge": True}
+    if mlb_key is not None:
+        metadata["mlb_key"] = mlb_key
+    if oodd_mlb_key is not None:
+        metadata["oodd_mlb_key"] = oodd_mlb_key
+
     return ImageQuery(
-        metadata={"is_from_edge": True},
+        metadata=metadata,
         id=generate_iq_id(),
         type=ImageQueryTypeEnum.image_query,
         created_at=datetime.now(timezone.utc),

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -65,9 +65,11 @@ def create_iq(  # noqa: PLR0913
     :param patience_time: The acceptable time to wait for a result.
     :param rois: The ROIs associated with the prediction, if applicable.
     :param text: The text associated with the prediction, if applicable.
-    :param mlb_key: KSUID of the primary MLB used for local inference. Stamped onto `metadata.mlb_key`
-        so callers of local/no-cloud detectors can identify which binary produced the result without
-        needing to escalate and re-fetch.
+    :param mlb_key: KSUID of the primary MLB used for local inference. Stamped onto
+        `metadata.edge_result.mlb_key` so callers of local/no-cloud detectors can identify which
+        binary produced the result without needing to escalate and re-fetch. The path mirrors the
+        cloud-side shape (see `generate_metadata_dict`), so consumers use the same
+        `metadata.edge_result.mlb_key` lookup regardless of whether the IQ escalated.
     :param oodd_mlb_key: KSUID of the OODD MLB, same purpose as `mlb_key`.
 
     :return: The created ImageQuery.
@@ -77,10 +79,13 @@ def create_iq(  # noqa: PLR0913
     result_type, result = _mode_to_result_and_type(mode, mode_configuration, confidence, result_value)
 
     metadata: dict[str, Any] = {"is_from_edge": True}
+    edge_result: dict[str, Any] = {}
     if mlb_key is not None:
-        metadata["mlb_key"] = mlb_key
+        edge_result["mlb_key"] = mlb_key
     if oodd_mlb_key is not None:
-        metadata["oodd_mlb_key"] = oodd_mlb_key
+        edge_result["oodd_mlb_key"] = oodd_mlb_key
+    if edge_result:
+        metadata["edge_result"] = edge_result
 
     return ImageQuery(
         metadata=metadata,

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -207,6 +207,10 @@ spec:
           mountPath: /opt/groundlight/edge/sqlite
         - name: edge-endpoint-persistent-volume
           mountPath: /opt/groundlight/edge/config
+        # Needed by run_inference() to read {detector}/{primary,oodd}/{version}/model_id.txt
+        # and stamp the MLB KSUID into edge_result for cloud-side debugging.
+        - name: edge-endpoint-persistent-volume
+          mountPath: /opt/groundlight/edge/serving/model-repo
         - name: device-info-volume
           mountPath: /opt/groundlight/device
         - name: escalation-queue-volume

--- a/test/api/test_utils.py
+++ b/test/api/test_utils.py
@@ -365,7 +365,8 @@ class TestCreateIQ:
             )
 
     def test_create_iq_stamps_mlb_keys_in_metadata(self):
-        """MLB keys should be stamped on iq.metadata when passed in."""
+        """MLB keys should be stamped under iq.metadata.edge_result when passed in,
+        mirroring the cloud-side shape produced by generate_metadata_dict."""
         iq = create_iq(
             detector_id=prefixed_ksuid("det_"),
             mode=ModeEnum.BINARY,
@@ -379,11 +380,11 @@ class TestCreateIQ:
             oodd_mlb_key="mlb_oodd_xyz",
         )
         assert iq.metadata["is_from_edge"] is True
-        assert iq.metadata["mlb_key"] == "mlb_primary_abc"
-        assert iq.metadata["oodd_mlb_key"] == "mlb_oodd_xyz"
+        assert iq.metadata["edge_result"]["mlb_key"] == "mlb_primary_abc"
+        assert iq.metadata["edge_result"]["oodd_mlb_key"] == "mlb_oodd_xyz"
 
-    def test_create_iq_omits_mlb_keys_when_not_provided(self):
-        """Default behavior should leave mlb_key/oodd_mlb_key absent from metadata."""
+    def test_create_iq_omits_edge_result_when_no_mlb_keys(self):
+        """When neither MLB key is passed, no edge_result sub-dict is written."""
         iq = create_iq(
             detector_id=prefixed_ksuid("det_"),
             mode=ModeEnum.BINARY,
@@ -394,11 +395,10 @@ class TestCreateIQ:
             is_done_processing=True,
             query="Test query",
         )
-        assert "mlb_key" not in iq.metadata
-        assert "oodd_mlb_key" not in iq.metadata
+        assert "edge_result" not in iq.metadata
 
     def test_create_iq_stamps_only_primary_mlb_key(self):
-        """When OODD is disabled, only mlb_key is populated."""
+        """When OODD is disabled, only mlb_key is populated under edge_result."""
         iq = create_iq(
             detector_id=prefixed_ksuid("det_"),
             mode=ModeEnum.BINARY,
@@ -410,8 +410,8 @@ class TestCreateIQ:
             query="Test query",
             mlb_key="mlb_primary_only",
         )
-        assert iq.metadata["mlb_key"] == "mlb_primary_only"
-        assert "oodd_mlb_key" not in iq.metadata
+        assert iq.metadata["edge_result"]["mlb_key"] == "mlb_primary_only"
+        assert "oodd_mlb_key" not in iq.metadata["edge_result"]
 
 
 class TestParseModelInfo:

--- a/test/api/test_utils.py
+++ b/test/api/test_utils.py
@@ -364,6 +364,55 @@ class TestCreateIQ:
                 query="Test query",
             )
 
+    def test_create_iq_stamps_mlb_keys_in_metadata(self):
+        """MLB keys should be stamped on iq.metadata when passed in."""
+        iq = create_iq(
+            detector_id=prefixed_ksuid("det_"),
+            mode=ModeEnum.BINARY,
+            mode_configuration=None,
+            result_value=0,
+            confidence=0.8,
+            confidence_threshold=self.confidence_threshold,
+            is_done_processing=True,
+            query="Test query",
+            mlb_key="mlb_primary_abc",
+            oodd_mlb_key="mlb_oodd_xyz",
+        )
+        assert iq.metadata["is_from_edge"] is True
+        assert iq.metadata["mlb_key"] == "mlb_primary_abc"
+        assert iq.metadata["oodd_mlb_key"] == "mlb_oodd_xyz"
+
+    def test_create_iq_omits_mlb_keys_when_not_provided(self):
+        """Default behavior should leave mlb_key/oodd_mlb_key absent from metadata."""
+        iq = create_iq(
+            detector_id=prefixed_ksuid("det_"),
+            mode=ModeEnum.BINARY,
+            mode_configuration=None,
+            result_value=0,
+            confidence=0.8,
+            confidence_threshold=self.confidence_threshold,
+            is_done_processing=True,
+            query="Test query",
+        )
+        assert "mlb_key" not in iq.metadata
+        assert "oodd_mlb_key" not in iq.metadata
+
+    def test_create_iq_stamps_only_primary_mlb_key(self):
+        """When OODD is disabled, only mlb_key is populated."""
+        iq = create_iq(
+            detector_id=prefixed_ksuid("det_"),
+            mode=ModeEnum.BINARY,
+            mode_configuration=None,
+            result_value=0,
+            confidence=0.8,
+            confidence_threshold=self.confidence_threshold,
+            is_done_processing=True,
+            query="Test query",
+            mlb_key="mlb_primary_only",
+        )
+        assert iq.metadata["mlb_key"] == "mlb_primary_only"
+        assert "oodd_mlb_key" not in iq.metadata
+
 
 class TestParseModelInfo:
     def test_parse_with_binary(self):

--- a/test/edge_inference/test_edge_inference_manager.py
+++ b/test/edge_inference/test_edge_inference_manager.py
@@ -203,3 +203,72 @@ class TestEdgeInferenceManager:
             # Assert that the mock_submit was called only once for primary inference, never for OODD
             assert mock_submit.call_count == 1
             mock_submit.assert_called_once_with(primary_inference_client_url, b"test_image", "image/jpeg")
+
+    def _write_model_id(self, repository: str, detector_id: str, version: int, ksuid: str, is_oodd: bool = False):
+        sub = "oodd" if is_oodd else "primary"
+        version_dir = os.path.join(repository, detector_id, sub, str(version))
+        os.makedirs(version_dir, exist_ok=True)
+        with open(os.path.join(version_dir, "model_id.txt"), "w") as f:
+            f.write(ksuid)
+
+    def test_run_inference_stamps_mlb_keys(self):
+        """With OODD enabled and model_id.txt present for both, output_dict carries both keys."""
+        mock_response = {
+            "multi_predictions": None,
+            "predictions": {"confidences": [0.54], "labels": [0]},
+            "secondary_predictions": None,
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            detector_id = "test_detector"
+            self._write_model_id(temp_dir, detector_id, 1, "prim_ksuid_abc")
+            self._write_model_id(temp_dir, detector_id, 1, "oodd_ksuid_xyz", is_oodd=True)
+
+            with mock.patch("app.core.edge_inference.submit_image_for_inference") as mock_submit:
+                mock_submit.return_value = mock_response
+                edge_manager = EdgeInferenceManager()
+                edge_manager.MODEL_REPOSITORY = temp_dir  # type: ignore
+                output = edge_manager.run_inference(detector_id, b"test_image", "image/jpeg", mode=ModeEnum.BINARY)
+
+                assert output["mlb_key"] == "prim_ksuid_abc"
+                assert output["oodd_mlb_key"] == "oodd_ksuid_xyz"
+
+    def test_run_inference_stamps_mlb_key_without_oodd(self):
+        """With separate_oodd_inference=False, only mlb_key is stamped."""
+        mock_response = {
+            "multi_predictions": None,
+            "predictions": {"confidences": [0.54], "labels": [0]},
+            "secondary_predictions": None,
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            detector_id = "test_detector"
+            self._write_model_id(temp_dir, detector_id, 1, "prim_ksuid_only")
+
+            with mock.patch("app.core.edge_inference.submit_image_for_inference") as mock_submit:
+                mock_submit.return_value = mock_response
+                edge_manager = EdgeInferenceManager(separate_oodd_inference=False)
+                edge_manager.MODEL_REPOSITORY = temp_dir  # type: ignore
+                output = edge_manager.run_inference(detector_id, b"test_image", "image/jpeg", mode=ModeEnum.BINARY)
+
+                assert output["mlb_key"] == "prim_ksuid_only"
+                assert "oodd_mlb_key" not in output
+
+    def test_run_inference_missing_model_id_is_nonfatal(self):
+        """Missing model_id.txt should simply omit the keys without raising or affecting inference."""
+        mock_response = {
+            "multi_predictions": None,
+            "predictions": {"confidences": [0.54], "labels": [0]},
+            "secondary_predictions": None,
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # No model_id.txt written; repository is empty.
+            with mock.patch("app.core.edge_inference.submit_image_for_inference") as mock_submit:
+                mock_submit.return_value = mock_response
+                edge_manager = EdgeInferenceManager()
+                edge_manager.MODEL_REPOSITORY = temp_dir  # type: ignore
+                output = edge_manager.run_inference("test_detector", b"test_image", "image/jpeg", mode=ModeEnum.BINARY)
+
+                assert "mlb_key" not in output
+                assert "oodd_mlb_key" not in output


### PR DESCRIPTION
## Summary

- `run_inference()` in `app/core/edge_inference.py` now attaches the currently-loaded primary (and OODD, when applicable) MLB KSUID to `output_dict` so cloud persists them on `Posicheck.metadata.edge_result`. Removes the need to infer edge MLBs by cross-referencing cloud supersession in OpenSearch for edge-vs-cloud debugging.
- Stamping is wrapped in `try/except` and guards each field on non-None reads, so a missing `model_id.txt` (first-boot race, disk issue, etc.) just omits the key without affecting inference.
- Helm: adds a second `/opt/groundlight/edge/serving/model-repo` mount to the `edge-endpoint` container in `edge-deployment.yaml`. The PVC was already mounted in that container at `/opt/groundlight/edge/sqlite`, but `MODEL_REPOSITORY_PATH` in `app/core/file_paths.py` resolves to `/opt/groundlight/edge/serving/model-repo`, where the `status-monitor` container already mounts it. Without this mount the new stamping code silently finds nothing.
- Additive and backward-compatible — no SDK changes, no `Posicheck` schema changes; older edges continue to omit the keys.

## Test plan

- [x] Unit: `pytest test/edge_inference/test_edge_inference_manager.py -v` — 7/7 pass (4 existing + 3 new: with-OODD, without-OODD, missing-model-id-nonfatal).
- [x] G4 integration (built `edge-endpoint:dev` via `deploy/bin/build-local-edge-endpoint-image.sh`, deployed via `make helm-install HELM_ARGS="--set edgeEndpointTag=dev ..."`):
  - [x] Happy path — fired 5 IQs against `det_2upHNr7q0U2xaX8atrVrqKmQ1Mb` (`edge_answers_with_escalation`). All 5 escalated with `edge_result.mlb_key` and `edge_result.oodd_mlb_key` matching live `model_id.txt` in the pod (primary v1, OODD v2).
  - [x] Negative path — moved primary `model_id.txt` aside; IQ still returned a valid result, `mlb_key` was cleanly absent, `oodd_mlb_key` remained present, no warnings in logs.
  - [x] Verified running image carries the new code: `kubectl exec ... grep 'Stamp the currently-loaded MLB' edge_inference.py`.