### PR TITLE
Improve profiling dashboard plots and merge cross-process trace spans

### DIFF
--- a/app/profiling/dashboard.py
+++ b/app/profiling/dashboard.py
@@ -35,10 +35,34 @@ def _():
     }
     FALLBACK_COLOR = "#B6B6B6"
 
+    # Qualitative palette used to auto-color spans that aren't in SPAN_COLORS.
+    AUTO_PALETTE = [
+        "#636EFA",
+        "#EF553B",
+        "#00CC96",
+        "#AB63FA",
+        "#FFA15A",
+        "#19D3F3",
+        "#FF6692",
+        "#B6E880",
+        "#FF97FF",
+        "#FECB52",
+        "#1F77B4",
+        "#FF7F0E",
+        "#2CA02C",
+        "#D62728",
+        "#9467BD",
+        "#8C564B",
+        "#E377C2",
+        "#7F7F7F",
+        "#BCBD22",
+        "#17BECF",
+    ]
+
     # How many recent traces to offer in the waterfall selector.
     MAX_TRACES_IN_SELECTOR = 50
 
-    return FALLBACK_COLOR, MAX_TRACES_IN_SELECTOR, SPAN_COLORS, mo
+    return AUTO_PALETTE, FALLBACK_COLOR, MAX_TRACES_IN_SELECTOR, SPAN_COLORS, mo
 
 
 @app.cell
@@ -350,14 +374,14 @@ def _(mo, traces):
     latency_over_time_spans = mo.ui.multiselect(
         options=_ordered,
         value=_defaults,
-        label="Spans to plot (re-run to apply)",
+        label="Spans to plot",
     )
     latency_over_time_spans
     return (latency_over_time_spans,)
 
 
 @app.cell
-def _(SPAN_COLORS, go, latency_over_time_spans, mo, traces):
+def _(AUTO_PALETTE, SPAN_COLORS, go, latency_over_time_spans, mo, traces):
     # Scatterplot of selected spans' durations over time, colored by span name.
     # Only spans chosen in the multiselect are embedded in the plot payload —
     # plotting every span can exceed marimo's output size limit.
@@ -379,32 +403,10 @@ def _(SPAN_COLORS, go, latency_over_time_spans, mo, traces):
     _ordered_names = sorted(_points_by_span.keys(), key=span_sort_key)
 
     # Assign a distinct color to every plotted span: use the explicit SPAN_COLORS
-    # mapping when available, otherwise cycle through a qualitative palette so
-    # spans without a predefined color still look distinct.
-    _palette = [
-        "#636EFA",
-        "#EF553B",
-        "#00CC96",
-        "#AB63FA",
-        "#FFA15A",
-        "#19D3F3",
-        "#FF6692",
-        "#B6E880",
-        "#FF97FF",
-        "#FECB52",
-        "#1F77B4",
-        "#FF7F0E",
-        "#2CA02C",
-        "#D62728",
-        "#9467BD",
-        "#8C564B",
-        "#E377C2",
-        "#7F7F7F",
-        "#BCBD22",
-        "#17BECF",
-    ]
+    # mapping when available, otherwise cycle through AUTO_PALETTE so spans
+    # without a predefined color still look distinct.
     _unknowns = [_n for _n in _ordered_names if _n not in SPAN_COLORS]
-    _auto_colors = {_n: _palette[_i % len(_palette)] for _i, _n in enumerate(_unknowns)}
+    _auto_colors = {_n: AUTO_PALETTE[_i % len(AUTO_PALETTE)] for _i, _n in enumerate(_unknowns)}
 
     if _ordered_names:
         _fig = go.Figure()
@@ -673,9 +675,12 @@ def build_waterfall(detail, spans, go, mo, span_colors, fallback_color):
         for child in reversed(children):
             stack.append((child, depth + 1))
 
-    placed_ids = {s.get("span_id") for s, _ in ordered}
+    # Track placed spans by object identity rather than span_id so that spans
+    # without a span_id don't all collapse onto a single "already placed"
+    # sentinel and get silently dropped by the orphan-fallback loop.
+    placed = {id(s) for s, _ in ordered}
     for s in spans:
-        if s.get("span_id") not in placed_ids:
+        if id(s) not in placed:
             ordered.append((s, 0))
 
     # Tint every descendant of a primary/OODD inference wrapper with the wrapper's

--- a/app/profiling/dashboard.py
+++ b/app/profiling/dashboard.py
@@ -223,7 +223,11 @@ def _(go, mo, traces):
             if _name and _dur is not None and _dur >= 0:
                 durations_by_span.setdefault(_name, []).append(_dur)
 
-    _ordered_names = sorted(durations_by_span.keys(), key=span_sort_key)
+    _ordered_names = sorted(
+        durations_by_span.keys(),
+        key=lambda n: sum(durations_by_span[n]) / len(durations_by_span[n]),
+        reverse=True,
+    )
 
     if _ordered_names:
         _fig = go.Figure()
@@ -234,6 +238,7 @@ def _(go, mo, traces):
             title="Latency Distribution by Span",
             yaxis_title="Duration (ms)",
             xaxis_title="Span",
+            xaxis=dict(categoryorder="array", categoryarray=_ordered_names),
             showlegend=True,
             height=450,
         )
@@ -334,11 +339,34 @@ def _(durations_by_span, go, make_subplots, mo, stats):
 
 
 @app.cell
-def _(FALLBACK_COLOR, SPAN_COLORS, go, mo, traces):
-    # Scatterplot of every span's duration over time, colored by span name.
-    # Each trace contributes one point per span, so cache hits vs misses and
-    # individual outliers per span type are directly visible. Click a legend
-    # entry to toggle that span on/off.
+def _(mo, traces):
+    _all_span_names = set()
+    for _t in traces:
+        for _s in _t.get("spans", []):
+            _n = _s.get("name")
+            if _n:
+                _all_span_names.add(_n)
+    _ordered = sorted(_all_span_names, key=span_sort_key)
+
+    _defaults = [
+        _n for _n in ("_submit_primary_inference", "_submit_oodd_inference") if _n in _all_span_names
+    ]
+
+    latency_over_time_spans = mo.ui.multiselect(
+        options=_ordered,
+        value=_defaults,
+        label="Spans to plot (re-run to apply)",
+    )
+    latency_over_time_spans
+    return (latency_over_time_spans,)
+
+
+@app.cell
+def _(SPAN_COLORS, go, latency_over_time_spans, mo, traces):
+    # Scatterplot of selected spans' durations over time, colored by span name.
+    # Only spans chosen in the multiselect are embedded in the plot payload —
+    # plotting every span can exceed marimo's output size limit.
+    _selected = set(latency_over_time_spans.value or [])
     _points_by_span: dict[str, list[tuple[str, float, str]]] = {}
     for _t in traces:
         _wall = _t.get("start_wall_time_iso", "")
@@ -347,18 +375,32 @@ def _(FALLBACK_COLOR, SPAN_COLORS, go, mo, traces):
             continue
         for _s in _t.get("spans", []):
             _name = _s.get("name")
+            if _name not in _selected:
+                continue
             _dur = _s.get("duration_ms")
-            if _name and _dur is not None and _dur >= 0:
+            if _dur is not None and _dur >= 0:
                 _points_by_span.setdefault(_name, []).append((_wall, _dur, _tid))
 
     _ordered_names = sorted(_points_by_span.keys(), key=span_sort_key)
+
+    # Assign a distinct color to every plotted span: use the explicit SPAN_COLORS
+    # mapping when available, otherwise cycle through a qualitative palette so
+    # spans without a predefined color still look distinct.
+    _palette = [
+        "#636EFA", "#EF553B", "#00CC96", "#AB63FA", "#FFA15A",
+        "#19D3F3", "#FF6692", "#B6E880", "#FF97FF", "#FECB52",
+        "#1F77B4", "#FF7F0E", "#2CA02C", "#D62728", "#9467BD",
+        "#8C564B", "#E377C2", "#7F7F7F", "#BCBD22", "#17BECF",
+    ]
+    _unknowns = [_n for _n in _ordered_names if _n not in SPAN_COLORS]
+    _auto_colors = {_n: _palette[_i % len(_palette)] for _i, _n in enumerate(_unknowns)}
 
     if _ordered_names:
         _fig = go.Figure()
         for _name in _ordered_names:
             _points = _points_by_span[_name]
             _fig.add_trace(
-                go.Scatter(
+                go.Scattergl(
                     x=[_p[0] for _p in _points],
                     y=[_p[1] for _p in _points],
                     mode="markers",
@@ -366,7 +408,7 @@ def _(FALLBACK_COLOR, SPAN_COLORS, go, mo, traces):
                     marker=dict(
                         size=5,
                         opacity=0.6,
-                        color=SPAN_COLORS.get(_name, FALLBACK_COLOR),
+                        color=SPAN_COLORS.get(_name, _auto_colors.get(_name)),
                     ),
                     customdata=[_p[2] for _p in _points],
                     hovertemplate=(
@@ -394,7 +436,7 @@ def _(FALLBACK_COLOR, SPAN_COLORS, go, mo, traces):
             ]
         )
     else:
-        _out = mo.md("## Latency Over Time\n\n*Not enough span data to plot.*")
+        _out = mo.md("## Latency Over Time\n\n*Select at least one span to plot.*")
 
     _out
 

--- a/app/profiling/dashboard.py
+++ b/app/profiling/dashboard.py
@@ -52,7 +52,6 @@ def _():
         sys.path.insert(0, _repo_root)
 
     import plotly.graph_objects as go
-    from plotly.subplots import make_subplots
 
     from app.profiling.data_loader import (
         compute_span_stats,
@@ -60,6 +59,7 @@ def _():
         get_detector_ids,
         get_trace_detail,
         load_traces,
+        merge_traces_by_id,
     )
     from app.profiling.manager import PROFILING_DIR
 
@@ -71,7 +71,7 @@ def _():
         get_trace_detail,
         go,
         load_traces,
-        make_subplots,
+        merge_traces_by_id,
     )
 
 
@@ -141,14 +141,20 @@ def _(detector_filter, mo, refresh, time_range):
 
 
 @app.cell
-def _(detector_filter, get_detector_ids, load_traces, mo, refresh, time_range, traces_dir):
+def _(detector_filter, get_detector_ids, load_traces, merge_traces_by_id, mo, refresh, time_range, traces_dir):
     # Reactive: re-runs when controls change or auto-refresh fires.
     _ = refresh
 
     _since_val = time_range.value  # mapped int from dict options; 0 means "all"
     _since = int(_since_val) if _since_val else None
     _det = detector_filter.value or None
-    traces = load_traces(traces_dir, since_minutes=_since, detector_id=_det)
+    # Load all records (no detector filter at load time) so that cross-process
+    # records sharing a trace_id can be merged. The inference-side records carry
+    # an empty detector_id and would otherwise be dropped before merge. Apply
+    # the detector filter to the merged trace set.
+    traces = merge_traces_by_id(load_traces(traces_dir, since_minutes=_since))
+    if _det:
+        traces = [t for t in traces if t.get("detector_id") == _det]
 
     if not traces:
         _summary = mo.callout(
@@ -252,26 +258,43 @@ def _(go, mo, traces):
 
 
 @app.cell
-def _(durations_by_span, go, make_subplots, mo, stats):
-    # Histograms: one subplot per span, with p50/p95/p99 shown as vertical lines.
-    # Each subplot gets its own x-axis so wildly different timescales (e.g. 2ms
-    # vs 300ms spans) each remain readable.
+def _(durations_by_span, mo):
+    # Dropdown to pick a single span for the histogram below. Default to "request"
+    # so the full per-request distribution is what you see first.
     _ordered_names = sorted(durations_by_span.keys(), key=span_sort_key)
-
     if _ordered_names:
-        _cols = 2
-        _rows = (len(_ordered_names) + _cols - 1) // _cols
-        # vertical_spacing is a fraction of TOTAL plot height between each row pair,
-        # so a fixed value compounds with row count. Scale it so total padding
-        # (rows-1) * spacing stays bounded, capped so the very-small-grid case still
-        # has visible breathing room.
-        _vspacing = min(0.08, 0.2 / max(1, _rows - 1))
-        _fig = make_subplots(
-            rows=_rows,
-            cols=_cols,
-            subplot_titles=_ordered_names,
-            horizontal_spacing=0.12,
-            vertical_spacing=_vspacing,
+        _options = {_n: _n for _n in _ordered_names}
+        _default = "request" if "request" in _options else _ordered_names[0]
+        histogram_span = mo.ui.dropdown(options=_options, value=_default, label="Histogram span")
+    else:
+        histogram_span = mo.ui.dropdown(options={}, label="Histogram span")
+    return (histogram_span,)
+
+
+@app.cell
+def _(durations_by_span, go, histogram_span, mo, stats):
+    # Render a single histogram for the selected span, with p50/p95/p99 vlines.
+    _name = histogram_span.value
+    _samples = durations_by_span.get(_name) if _name else None
+
+    if not _samples:
+        _out = mo.vstack(
+            [
+                mo.md("### Histograms _(p50 green, p95 orange, p99 red)_"),
+                histogram_span,
+                mo.md("*No span data to plot.*"),
+            ]
+        )
+    else:
+        _fig = go.Figure()
+        _fig.add_trace(
+            go.Histogram(
+                x=_samples,
+                nbinsx=40,
+                showlegend=False,
+                marker_color="#AAB6FB",
+                hovertemplate="%{x:.1f}ms: %{y} samples<extra></extra>",
+            )
         )
 
         _percentile_styles = [
@@ -279,61 +302,35 @@ def _(durations_by_span, go, make_subplots, mo, stats):
             ("p95", "#FFA15A"),
             ("p99", "#EF553B"),
         ]
-
-        for _i, _name in enumerate(_ordered_names):
-            _row = (_i // _cols) + 1
-            _col = (_i % _cols) + 1
-
-            _fig.add_trace(
-                go.Histogram(
-                    x=durations_by_span[_name],
-                    nbinsx=40,
-                    showlegend=False,
-                    marker_color="#AAB6FB",
-                    hovertemplate="%{x:.1f}ms: %{y} samples<extra></extra>",
-                ),
-                row=_row,
-                col=_col,
+        _s = stats.get(_name, {})
+        for _label, _color in _percentile_styles:
+            _val = _s.get(_label)
+            if _val is None:
+                continue
+            _fig.add_vline(
+                x=_val,
+                line=dict(color=_color, dash="dash", width=1.5),
+                annotation_text=_label,
+                annotation_position="top",
+                annotation_font_color=_color,
             )
 
-            # Overlay percentile lines; label only the first subplot to act as a legend.
-            # Any annotation_* kwarg (even with annotation_text=None) triggers plotly's
-            # default "new text" label, so we only pass annotation kwargs when we want one.
-            _s = stats.get(_name, {})
-            _label_this_subplot = _i == 0
-            for _label, _color in _percentile_styles:
-                _val = _s.get(_label)
-                if _val is None:
-                    continue
-                _vline_kwargs = dict(
-                    x=_val,
-                    line=dict(color=_color, dash="dash", width=1.5),
-                    row=_row,
-                    col=_col,
-                )
-                if _label_this_subplot:
-                    _vline_kwargs["annotation_text"] = _label
-                    _vline_kwargs["annotation_position"] = "top"
-                    _vline_kwargs["annotation_font_color"] = _color
-                _fig.add_vline(**_vline_kwargs)
-
-            _fig.update_xaxes(title_text="Duration (ms)", row=_row, col=_col)
-            _fig.update_yaxes(title_text="Count", row=_row, col=_col)
-
         _fig.update_layout(
-            height=320 * _rows,
+            xaxis_title="Duration (ms)",
+            yaxis_title="Count",
+            height=400,
             showlegend=False,
-            margin=dict(t=50, b=40),
+            margin=dict(t=40, b=40),
+            title=_name,
         )
 
         _out = mo.vstack(
             [
                 mo.md("### Histograms _(p50 green, p95 orange, p99 red)_"),
+                histogram_span,
                 mo.ui.plotly(_fig),
             ]
         )
-    else:
-        _out = mo.md("### Histograms\n\n*No span data to plot.*")
 
     _out
 
@@ -645,27 +642,78 @@ def _(FALLBACK_COLOR, SPAN_COLORS, get_trace_detail, go, mo, trace_selector, tra
 
 @app.function
 def build_waterfall(detail, spans, go, mo, span_colors, fallback_color):
-    """Build a Gantt-style waterfall figure and span table for a single trace."""
+    """Build a Gantt-style waterfall figure and span table for a single trace.
+
+    Spans are ordered by depth-first pre-order traversal of the parent/child tree
+    so children sit directly under their parent, and y-axis labels are indented by
+    depth. Each span gets its own row (indexed by an integer y-position) so spans
+    that share a name — e.g. an inference-server span emitted under both the
+    primary and OODD wrappers — don't collide on the same row.
+    """
     root_start = min(s.get("start_time_ns", 0) for s in spans)
 
-    bars = []
+    span_by_id = {s.get("span_id"): s for s in spans if s.get("span_id")}
+    children_by_parent: dict = {}
     for s in spans:
+        pid = s.get("parent_span_id")
+        if pid not in span_by_id:
+            pid = None  # treat orphans (parent missing from merged set) as roots
+        children_by_parent.setdefault(pid, []).append(s)
+    for kids in children_by_parent.values():
+        kids.sort(key=lambda s: s.get("start_time_ns", 0))
+
+    ordered: list = []  # list of (span, depth) in DFS pre-order
+    # Iterative DFS: marimo rewrites function names with cell-local prefixes,
+    # which breaks self-recursion inside nested helpers.
+    stack: list = [(s, 0) for s in reversed(children_by_parent.get(None, []))]
+    while stack:
+        node, depth = stack.pop()
+        ordered.append((node, depth))
+        children = children_by_parent.get(node.get("span_id"), [])
+        for child in reversed(children):
+            stack.append((child, depth + 1))
+
+    placed_ids = {s.get("span_id") for s, _ in ordered}
+    for s in spans:
+        if s.get("span_id") not in placed_ids:
+            ordered.append((s, 0))
+
+    # Tint every descendant of a primary/OODD inference wrapper with the wrapper's
+    # color so it's visually obvious which branch a given inference-pod span ran
+    # under. Walks the subtree under each wrapper span using the same iterative DFS.
+    inherited_color: dict = {}
+    for s in spans:
+        if s.get("name") in ("_submit_primary_inference", "_submit_oodd_inference"):
+            wrapper_color = span_colors.get(s.get("name"), fallback_color)
+            sub_stack: list = [s.get("span_id")]
+            while sub_stack:
+                pid = sub_stack.pop()
+                for child in children_by_parent.get(pid, []):
+                    cid = child.get("span_id")
+                    if cid is not None and cid not in inherited_color:
+                        inherited_color[cid] = wrapper_color
+                        sub_stack.append(cid)
+
+    fig = go.Figure()
+    tickvals: list = []
+    ticktext: list = []
+    for idx, (s, depth) in enumerate(ordered):
         dur = s.get("duration_ms", 0)
         if dur is None or dur < 0:
             continue
         name = s.get("name", "unknown")
         start_ms = (s.get("start_time_ns", 0) - root_start) / 1_000_000
-        bars.append((name, start_ms, dur))
-
-    fig = go.Figure()
-    for name, start_ms, dur in bars:
+        label = ("    " * depth) + name
+        tickvals.append(idx)
+        ticktext.append(label)
+        bar_color = inherited_color.get(s.get("span_id")) or span_colors.get(name, fallback_color)
         fig.add_trace(
             go.Bar(
-                y=[name],
+                y=[idx],
                 x=[dur],
                 base=[start_ms],
                 orientation="h",
-                marker_color=span_colors.get(name, fallback_color),
+                marker_color=bar_color,
                 name=name,
                 customdata=[[start_ms + dur, dur]],
                 hovertemplate=(
@@ -679,21 +727,26 @@ def build_waterfall(detail, spans, go, mo, span_colors, fallback_color):
 
     fig.update_layout(
         xaxis_title="Time from request start (ms)",
-        height=max(200, 40 * len(bars) + 100),
+        height=max(200, 28 * len(ordered) + 100),
         barmode="overlay",
-        yaxis=dict(autorange="reversed"),
-        margin=dict(t=20, b=40),
+        yaxis=dict(
+            tickmode="array",
+            tickvals=tickvals,
+            ticktext=ticktext,
+            autorange="reversed",
+        ),
+        margin=dict(t=20, b=40, l=320),
     )
 
     span_table = []
-    for s in spans:
+    for s, depth in ordered:
         annotations = s.get("annotations") or {}
         annotation_str = ", ".join(f"{k}={v}" for k, v in sorted(annotations.items())) if annotations else ""
         start_ms = (s.get("start_time_ns", 0) - root_start) / 1_000_000
         dur = s.get("duration_ms", 0) or 0
         span_table.append(
             {
-                "Span": s.get("name", "unknown"),
+                "Span": ("    " * depth) + s.get("name", "unknown"),
                 "Start (ms)": round(start_ms, 2),
                 "End (ms)": round(start_ms + dur, 2),
                 "Duration (ms)": round(dur, 2),

--- a/app/profiling/dashboard.py
+++ b/app/profiling/dashboard.py
@@ -348,9 +348,7 @@ def _(mo, traces):
                 _all_span_names.add(_n)
     _ordered = sorted(_all_span_names, key=span_sort_key)
 
-    _defaults = [
-        _n for _n in ("_submit_primary_inference", "_submit_oodd_inference") if _n in _all_span_names
-    ]
+    _defaults = [_n for _n in ("_submit_primary_inference", "_submit_oodd_inference") if _n in _all_span_names]
 
     latency_over_time_spans = mo.ui.multiselect(
         options=_ordered,
@@ -387,10 +385,26 @@ def _(SPAN_COLORS, go, latency_over_time_spans, mo, traces):
     # mapping when available, otherwise cycle through a qualitative palette so
     # spans without a predefined color still look distinct.
     _palette = [
-        "#636EFA", "#EF553B", "#00CC96", "#AB63FA", "#FFA15A",
-        "#19D3F3", "#FF6692", "#B6E880", "#FF97FF", "#FECB52",
-        "#1F77B4", "#FF7F0E", "#2CA02C", "#D62728", "#9467BD",
-        "#8C564B", "#E377C2", "#7F7F7F", "#BCBD22", "#17BECF",
+        "#636EFA",
+        "#EF553B",
+        "#00CC96",
+        "#AB63FA",
+        "#FFA15A",
+        "#19D3F3",
+        "#FF6692",
+        "#B6E880",
+        "#FF97FF",
+        "#FECB52",
+        "#1F77B4",
+        "#FF7F0E",
+        "#2CA02C",
+        "#D62728",
+        "#9467BD",
+        "#8C564B",
+        "#E377C2",
+        "#7F7F7F",
+        "#BCBD22",
+        "#17BECF",
     ]
     _unknowns = [_n for _n in _ordered_names if _n not in SPAN_COLORS]
     _auto_colors = {_n: _palette[_i % len(_palette)] for _i, _n in enumerate(_unknowns)}

--- a/app/profiling/data_loader.py
+++ b/app/profiling/data_loader.py
@@ -177,10 +177,44 @@ def get_trace_detail(traces: list[dict], trace_id: str) -> dict | None:
     matches = [t for t in traces if t.get("trace_id") == trace_id]
     if not matches:
         return None
+    return _merge_trace_records(matches)
+
+
+def merge_traces_by_id(traces: list[dict]) -> list[dict]:
+    """Group records by trace_id and merge into one record per trace.
+
+    Records can be split across processes (edge endpoint + inference server)
+    that share a trace_id but contribute disjoint span sets. This produces
+    one merged dict per trace_id with the union of spans (deduped by span_id).
+    Metadata (detector_id, start_wall_time_iso, ...) comes from the record
+    carrying the most informative detector_id, breaking ties by span count
+    so the most "complete" record wins. Records without a trace_id are dropped.
+    """
+    by_id: dict[str, list[dict]] = {}
+    for t in traces:
+        tid = t.get("trace_id")
+        if tid:
+            by_id.setdefault(tid, []).append(t)
+
+    merged_list: list[dict] = []
+    for group in by_id.values():
+        merged_list.append(_merge_trace_records(group))
+    return merged_list
+
+
+def _merge_trace_records(records: list[dict]) -> dict:
+    """Merge a list of records sharing a trace_id into one record."""
+
+    def _info_score(r: dict) -> tuple[int, int]:
+        det = (r.get("detector_id") or "").strip()
+        det_score = 2 if det and det != "unknown" else (1 if det else 0)
+        return (det_score, len(r.get("spans") or []))
+
+    base = max(records, key=_info_score)
 
     seen_span_ids: set[str] = set()
     merged_spans: list[dict] = []
-    for t in matches:
+    for t in records:
         for s in t.get("spans", []):
             sid = s.get("span_id")
             if sid is not None:
@@ -189,7 +223,7 @@ def get_trace_detail(traces: list[dict], trace_id: str) -> dict | None:
                 seen_span_ids.add(sid)
             merged_spans.append(s)
 
-    result = dict(matches[0])
+    result = dict(base)
     result["spans"] = sorted(merged_spans, key=lambda s: s.get("start_time_ns", 0))
     return result
 

--- a/app/profiling/data_loader.py
+++ b/app/profiling/data_loader.py
@@ -167,13 +167,31 @@ def get_detector_ids(traces: list[dict]) -> list[str]:
 
 
 def get_trace_detail(traces: list[dict], trace_id: str) -> dict | None:
-    """Find a specific trace by ID and return it with spans sorted by start_time_ns."""
-    for trace in traces:
-        if trace.get("trace_id") == trace_id:
-            result = dict(trace)
-            result["spans"] = sorted(result.get("spans", []), key=lambda s: s.get("start_time_ns", 0))
-            return result
-    return None
+    """Find a specific trace by ID and return it with spans sorted by start_time_ns.
+
+    Spans for one trace_id can be split across multiple records — the edge endpoint
+    and the inference server each write their own record with the same trace_id but
+    a disjoint span set. Merge all matching records so the waterfall shows the full
+    cross-process tree. Spans are deduped by span_id (first record wins).
+    """
+    matches = [t for t in traces if t.get("trace_id") == trace_id]
+    if not matches:
+        return None
+
+    seen_span_ids: set[str] = set()
+    merged_spans: list[dict] = []
+    for t in matches:
+        for s in t.get("spans", []):
+            sid = s.get("span_id")
+            if sid is not None:
+                if sid in seen_span_ids:
+                    continue
+                seen_span_ids.add(sid)
+            merged_spans.append(s)
+
+    result = dict(matches[0])
+    result["spans"] = sorted(merged_spans, key=lambda s: s.get("start_time_ns", 0))
+    return result
 
 
 def _stats_dict(durations: list[float]) -> dict:

--- a/test/profiling/test_data_loader.py
+++ b/test/profiling/test_data_loader.py
@@ -10,6 +10,7 @@ from app.profiling.data_loader import (
     get_detector_ids,
     get_trace_detail,
     load_traces,
+    merge_traces_by_id,
 )
 
 
@@ -541,6 +542,109 @@ class TestGetTraceDetail:
         ]
         result = get_trace_detail(traces, "t1")
         assert len(result["spans"]) == 1
+
+
+class TestMergeTracesById:
+    def test_groups_multiple_trace_ids(self):
+        a1 = _make_trace_dict(trace_id="a")
+        a2 = _make_trace_dict(trace_id="a", detector_id="", spans=[])
+        b1 = _make_trace_dict(trace_id="b")
+        merged = merge_traces_by_id([a1, a2, b1])
+        assert {t["trace_id"] for t in merged} == {"a", "b"}
+
+    def test_drops_records_without_trace_id(self):
+        good = _make_trace_dict(trace_id="t1")
+        bad = _make_trace_dict(trace_id="t1")
+        bad["trace_id"] = None
+        merged = merge_traces_by_id([good, bad])
+        assert len(merged) == 1
+        assert merged[0]["trace_id"] == "t1"
+
+    def test_metadata_prefers_real_detector_id_over_more_spans(self):
+        # Edge record carries the real detector_id but only one span.
+        edge_record = _make_trace_dict(
+            trace_id="t1",
+            detector_id="det_real",
+            spans=[
+                {
+                    "name": "request",
+                    "trace_id": "t1",
+                    "span_id": "edge1",
+                    "parent_span_id": None,
+                    "start_time_ns": 0,
+                    "end_time_ns": 100,
+                    "duration_ms": 0.0001,
+                    "annotations": {},
+                },
+            ],
+        )
+        # Inference record has empty detector_id but more spans — should NOT
+        # win the metadata tug-of-war: real detector_id beats span count.
+        inference_record = _make_trace_dict(
+            trace_id="t1",
+            detector_id="",
+            spans=[
+                {
+                    "name": f"inf_{i}",
+                    "trace_id": "t1",
+                    "span_id": f"inf{i}",
+                    "parent_span_id": "edge1",
+                    "start_time_ns": 10 + i,
+                    "end_time_ns": 20 + i,
+                    "duration_ms": 0.00001,
+                    "annotations": {},
+                }
+                for i in range(5)
+            ],
+        )
+        merged = merge_traces_by_id([inference_record, edge_record])
+        assert len(merged) == 1
+        assert merged[0]["detector_id"] == "det_real"
+        # Spans from both records are still unioned.
+        assert len(merged[0]["spans"]) == 6
+
+    def test_metadata_breaks_tie_by_span_count_when_detector_score_matches(self):
+        # Both records have empty detector_id (det_score=0). The one with more
+        # spans should win the metadata tie-break.
+        small = _make_trace_dict(
+            trace_id="t1",
+            detector_id="",
+            start_wall_time_iso="2026-01-01T00:00:00+00:00",
+            spans=[
+                {
+                    "name": "a",
+                    "trace_id": "t1",
+                    "span_id": "a1",
+                    "parent_span_id": None,
+                    "start_time_ns": 0,
+                    "end_time_ns": 1,
+                    "duration_ms": 0.000001,
+                    "annotations": {},
+                },
+            ],
+        )
+        big = _make_trace_dict(
+            trace_id="t1",
+            detector_id="",
+            start_wall_time_iso="2026-02-02T00:00:00+00:00",
+            spans=[
+                {
+                    "name": f"b{i}",
+                    "trace_id": "t1",
+                    "span_id": f"b{i}",
+                    "parent_span_id": None,
+                    "start_time_ns": i,
+                    "end_time_ns": i + 1,
+                    "duration_ms": 0.000001,
+                    "annotations": {},
+                }
+                for i in range(3)
+            ],
+        )
+        merged = merge_traces_by_id([small, big])
+        assert len(merged) == 1
+        # Wall time comes from `big` since it has more spans.
+        assert merged[0]["start_wall_time_iso"] == "2026-02-02T00:00:00+00:00"
 
 
 class TestDashboardSmoke:

--- a/test/profiling/test_data_loader.py
+++ b/test/profiling/test_data_loader.py
@@ -488,6 +488,60 @@ class TestGetTraceDetail:
     def test_empty_traces(self):
         assert get_trace_detail([], "t1") is None
 
+    def test_merges_spans_across_records_with_same_trace_id(self):
+        edge_record = _make_trace_dict(
+            trace_id="t1",
+            spans=[
+                {
+                    "name": "request",
+                    "trace_id": "t1",
+                    "span_id": "edge1",
+                    "parent_span_id": None,
+                    "start_time_ns": 0,
+                    "end_time_ns": 100,
+                    "duration_ms": 0.0001,
+                    "annotations": {},
+                },
+            ],
+        )
+        inference_record = _make_trace_dict(
+            trace_id="t1",
+            spans=[
+                {
+                    "name": "model_forward",
+                    "trace_id": "t1",
+                    "span_id": "inf1",
+                    "parent_span_id": "edge1",
+                    "start_time_ns": 25,
+                    "end_time_ns": 75,
+                    "duration_ms": 0.00005,
+                    "annotations": {},
+                },
+            ],
+        )
+        result = get_trace_detail([edge_record, inference_record], "t1")
+        assert result is not None
+        names = [s["name"] for s in result["spans"]]
+        assert names == ["request", "model_forward"]
+
+    def test_dedupes_spans_by_span_id(self):
+        span = {
+            "name": "request",
+            "trace_id": "t1",
+            "span_id": "s1",
+            "parent_span_id": None,
+            "start_time_ns": 0,
+            "end_time_ns": 100,
+            "duration_ms": 0.0001,
+            "annotations": {},
+        }
+        traces = [
+            _make_trace_dict(trace_id="t1", spans=[span]),
+            _make_trace_dict(trace_id="t1", spans=[span]),
+        ]
+        result = get_trace_detail(traces, "t1")
+        assert len(result["spans"]) == 1
+
 
 class TestDashboardSmoke:
     """Smoke tests for the Marimo dashboard. Skipped when the `profiling` dependency


### PR DESCRIPTION
 ## Summary
  Improvements to the Marimo profiling dashboard, focused on making cross-process traces actually readable and tightening a few plot-side rough edges.

  ## Changes

  **Cross-process trace merging** (`data_loader.py`)
  - New `merge_traces_by_id()` unifies records that share a `trace_id`. The edge endpoint and inference server each emit their own record per request, so without merging the waterfall only ever shows half the tree. Spans are deduped by `span_id`; metadata comes from the most "informative" record (real `detector_id` > `"unknown"` > empty, then span count).
  - The dashboard now loads traces *unfiltered* and applies the detector filter post-merge, because the inference-side record carries an empty `detector_id` and would otherwise be dropped before merge.

  **Waterfall hierarchy** (`dashboard.py`)
  - Spans are ordered by depth-first pre-order over `parent_span_id` with depth-indented y-axis labels, so children sit directly under their parent instead of getting reordered by start time.
  - Each span gets its own row (indexed by integer y-position) so spans that share a name across primary/OODD branches don't collide.
  - Descendants of `_submit_primary_inference` / `_submit_oodd_inference` inherit their wrapper's color, making it visually obvious which branch a given inference-pod span ran under.

  **Histogram UX**
  - Replaced the multi-subplot grid (unreadable when spans had wildly different timescales — 2ms vs 300ms) with a span-selector dropdown plus a single histogram. Default is `request`.

  **Latency-over-time scatter**
  - Now opt-in via a multiselect (defaults to the two inference wrappers). Plotting every span exceeded marimo's output payload size on busy traces.
  - Switched to `Scattergl` for perf, and unmapped spans cycle through a qualitative palette (hoisted to module constants) instead of all collapsing to the gray fallback.

  **Box plot** ordering switched from alphabetical to mean duration descending so the slowest spans surface first.