### PR TITLE
Add "Configuration" section to "Groundlight Edge Endpoint Status" page

### DIFF
--- a/app/metrics/system_metrics.py
+++ b/app/metrics/system_metrics.py
@@ -71,17 +71,20 @@ def get_namespace() -> str:
 
 
 def get_deployments() -> str:
-    """Return a string listing all deployment names in the edge namespace."""
+    """Return a JSON string listing all deployment names in the edge namespace.
+
+    Emitted as a single string (rather than a list) to keep OpenSearch from
+    indexing one field per deployment. Use json.dumps so consumers (incl. the
+    status page) can JSON.parse it back into a real list for display.
+    """
     config.load_incluster_config()
     v1_apps = client.AppsV1Api()
 
     namespace = get_namespace()
     deployments = v1_apps.list_namespaced_deployment(namespace=namespace)
 
-    deployment_names = []
-    for dep in deployments.items:
-        deployment_names.append(f"{dep.metadata.namespace}/{dep.metadata.name}")
-    return str(deployment_names)
+    deployment_names = [f"{dep.metadata.namespace}/{dep.metadata.name}" for dep in deployments.items]
+    return json.dumps(deployment_names)
 
 
 def get_pods() -> str:

--- a/app/metrics/system_metrics.py
+++ b/app/metrics/system_metrics.py
@@ -71,20 +71,17 @@ def get_namespace() -> str:
 
 
 def get_deployments() -> str:
-    """Return a JSON string listing all deployment names in the edge namespace.
-
-    Emitted as a single string (rather than a list) to keep OpenSearch from
-    indexing one field per deployment. Use json.dumps so consumers (incl. the
-    status page) can JSON.parse it back into a real list for display.
-    """
+    """Return a string listing all deployment names in the edge namespace."""
     config.load_incluster_config()
     v1_apps = client.AppsV1Api()
 
     namespace = get_namespace()
     deployments = v1_apps.list_namespaced_deployment(namespace=namespace)
 
-    deployment_names = [f"{dep.metadata.namespace}/{dep.metadata.name}" for dep in deployments.items]
-    return json.dumps(deployment_names)
+    deployment_names = []
+    for dep in deployments.items:
+        deployment_names.append(f"{dep.metadata.namespace}/{dep.metadata.name}")
+    return str(deployment_names)
 
 
 def get_pods() -> str:

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -180,10 +180,41 @@ def build_metrics(state):
         }
     return {
         "device_info": {"hostname": "mock-device", "ip": "10.0.0.1"},
-        "activity_metrics": {},
+        "activity_metrics": {
+            "activity_hour": "2026-04-29_19",
+            "num_detectors_lifetime": state["num_detectors"],
+            "num_detectors_active_1h": state["num_detectors"],
+            "confidence_histogram": {
+                "version": 2,
+                "bucket_width": 5,
+                "counts": [61, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 9, 48, 269, 131, 4],
+            },
+        },
         "failed_escalations": {},
         "detector_details": json.dumps(detector_details),
         "k3s_stats": {},
+    }
+
+
+def build_edge_config(state):
+    """Build a synthetic /edge-config payload mirroring EdgeConfigManager.active().to_payload()."""
+    detectors = []
+    for i in range(state["num_detectors"]):
+        d = _make_detector(i)
+        detectors.append({"detector_id": d["id"], "edge_inference_config": "default"})
+    return {
+        "global_config": {
+            "confident_audit_rate": 0.01,
+            "refresh_rate": 60,
+        },
+        "edge_inference_configs": {
+            "default": {
+                "enabled": True,
+                "always_return_edge_prediction": True,
+                "min_time_between_escalations": 2.0,
+            },
+        },
+        "detectors": detectors,
     }
 
 
@@ -196,6 +227,8 @@ class MockHandler(BaseHTTPRequestHandler):
                 data = build_resources(state)
             elif self.path == "/status/metrics.json":
                 data = build_metrics(state)
+            elif self.path == "/edge-config":
+                data = build_edge_config(state)
             else:
                 self.send_error(404)
                 return

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -192,7 +192,24 @@ def build_metrics(state):
         },
         "failed_escalations": {},
         "detector_details": json.dumps(detector_details),
-        "k3s_stats": {},
+        "k3s_stats": {
+            "deployments": json.dumps(["edge/edge-endpoint", "edge/edge-endpoint-network-healer"]),
+            "pod_statuses": json.dumps(
+                {
+                    "edge-endpoint-5755bcc876-2z6cq": "Running",
+                    "edge-endpoint-network-healer-5c9f996f4f-zzlk5": "Running",
+                    "create-ecr-creds-f9jhn": "Failed",
+                }
+            ),
+            "container_images": json.dumps(
+                {
+                    "edge-endpoint-5755bcc876-2z6cq": {
+                        "edge-endpoint": "ecr.amazonaws.com/edge-endpoint:dev@sha256:abc123",
+                        "nginx": "docker.io/library/nginx@sha256:def456",
+                    },
+                }
+            ),
+        },
     }
 
 

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -164,10 +164,41 @@ def build_resources(state):
     }
 
 
+_PIPELINE_CONFIG_BASIC = "generic-cached-timm\ncalibrated-mlp"
+
+# Realistic-looking multi-stage pipeline used to exercise YAML syntax
+# highlighting in the Pipeline column. Stages have nested keys, strings,
+# numbers, and booleans so every token type renders.
+_PIPELINE_CONFIG_RICH = """\
+stages:
+  - name: preprocess
+    type: image-resize
+    params:
+      target_height: 224
+      target_width: 224
+      interpolation: bilinear
+  - name: backbone
+    type: generic-cached-timm
+    params:
+      model: tf_efficientnet_b0
+      pretrained: true
+      cache_features: true
+  - name: head
+    type: calibrated-mlp
+    params:
+      hidden_dim: 256
+      dropout: 0.1
+      temperature: 1.4
+"""
+
+
 def build_metrics(state):
     detector_details = {}
     for i in range(state["num_detectors"]):
         d = _make_detector(i)
+        # Give the first detector a richer multi-stage pipeline so the
+        # Pipeline column actually exercises YAML syntax highlighting in dev.
+        pipeline_config = _PIPELINE_CONFIG_RICH if i == 0 else _PIPELINE_CONFIG_BASIC
         detector_details[d["id"]] = {
             "detector_name": d["name"],
             "status": "ready",
@@ -175,7 +206,7 @@ def build_metrics(state):
             "mode": "BINARY",
             "deploy_time": f"2026-04-10T10:{i:02d}:00Z",
             "last_updated_time": "2026-04-10T19:30:00Z",
-            "pipeline_config": "generic-cached-timm\ncalibrated-mlp",
+            "pipeline_config": pipeline_config,
             "edge_inference_config": {"enabled": True, "always_return_edge_prediction": True},
         }
     return {
@@ -189,6 +220,16 @@ def build_metrics(state):
                 "bucket_width": 5,
                 "counts": [61, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 9, 48, 269, 131, 4],
             },
+            "detector_activity_previous_hour": json.dumps(
+                {
+                    _make_detector(i)["id"]: {
+                        "hourly_total_iqs": 240 - 30 * i,
+                        "below_threshold_iqs": {"YES": 4, "NO": 1},
+                        "escalations": {"YES": 1},
+                    }
+                    for i in range(min(state["num_detectors"], 3))
+                }
+            ),
         },
         "failed_escalations": {},
         "detector_details": json.dumps(detector_details),

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -234,7 +234,11 @@ def build_metrics(state):
         "failed_escalations": {},
         "detector_details": json.dumps(detector_details),
         "k3s_stats": {
-            "deployments": json.dumps(["edge/edge-endpoint", "edge/edge-endpoint-network-healer"]),
+            # Mirror production: get_deployments() in system_metrics.py uses
+            # str(list) (Python repr with single quotes), not json.dumps. The
+            # frontend rehydrate path leaves it as a string since it's not
+            # valid JSON.
+            "deployments": str(["edge/edge-endpoint", "edge/edge-endpoint-network-healer"]),
             "pod_statuses": json.dumps(
                 {
                     "edge-endpoint-5755bcc876-2z6cq": "Running",

--- a/app/status_monitor/frontend/package-lock.json
+++ b/app/status_monitor/frontend/package-lock.json
@@ -15,7 +15,8 @@
         "postcss-simple-vars": "^7.0.1",
         "react": "^19",
         "react-dom": "^19",
-        "recharts": "^3.7.0"
+        "recharts": "^3.7.0",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4",
@@ -2488,6 +2489,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/app/status_monitor/frontend/package.json
+++ b/app/status_monitor/frontend/package.json
@@ -16,7 +16,8 @@
     "postcss-simple-vars": "^7.0.1",
     "react": "^19",
     "react-dom": "^19",
-    "recharts": "^3.7.0"
+    "recharts": "^3.7.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4",

--- a/app/status_monitor/frontend/src/App.css
+++ b/app/status_monitor/frontend/src/App.css
@@ -64,6 +64,20 @@ body {
   font-size: 0.8em;
 }
 
+/* CollapsibleSection title row. Slight padding + negative margin so the
+   hover background doesn't shift the layout, and a subtle tint on hover so
+   the click target reads as interactive. */
+.collapsible-section-trigger {
+  border-radius: 4px;
+  padding: 4px 6px;
+  margin: -4px -6px;
+  width: fit-content;
+  transition: background-color 100ms ease;
+}
+.collapsible-section-trigger:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
 /* SegmentedControl styling for the yaml/json toggle inside the dark gray
    Configuration header bar. Solid dark monochrome pill with a mid-gray
    active indicator. */

--- a/app/status_monitor/frontend/src/App.css
+++ b/app/status_monitor/frontend/src/App.css
@@ -64,6 +64,20 @@ body {
   font-size: 0.8em;
 }
 
+/* SegmentedControl styling for the yaml/json toggle inside the dark gray
+   Configuration header bar. Solid dark monochrome pill with a mid-gray
+   active indicator. */
+.dark-pill-toggle-root {
+  background-color: #1f1d20;
+  border: none;
+}
+.dark-pill-toggle-indicator {
+  background-color: #5a585c;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+.dark-pill-toggle-label { color: rgba(255, 255, 255, 0.55); }
+.dark-pill-toggle-label[data-active] { color: #fff; }
+
 /* Recharts donut tooltip -- z-index ensures it renders above the center label */
 .recharts-tooltip-wrapper {
   z-index: 10 !important;

--- a/app/status_monitor/frontend/src/App.jsx
+++ b/app/status_monitor/frontend/src/App.jsx
@@ -34,15 +34,6 @@ const parseIfJson = (value) => {
   return value;
 };
 
-const parseSection = (section) => {
-  if (!section) return section;
-  const parsed = { ...section };
-  for (const [key, value] of Object.entries(parsed)) {
-    parsed[key] = parseIfJson(value);
-  }
-  return parsed;
-};
-
 // Pretty-print JSON like JSON.stringify(value, null, indent), but keep arrays
 // of pure primitives on a single line so e.g. histogram counts don't take up
 // an entire vertical column.
@@ -74,6 +65,11 @@ const stringifyCompactArrays = (value, indent = 2) => {
 
 const SECTION_TITLE_STYLE = { fontSize: "1.25em", fontWeight: 500, color: "#1F1D23" };
 
+// Stable references for CodeSection's `languages` prop so memoization isn't
+// invalidated by fresh array literals on every render.
+const JSON_ONLY = ["json"];
+const YAML_OR_JSON = ["yaml", "json"];
+
 function GenericSectionSkeleton() {
   return (
     <Paper shadow="xs" p="md" radius="sm">
@@ -104,43 +100,57 @@ function CheckIcon() {
 
 // Single code-block widget used for every "view this dict as code" section on
 // the page. Renders a slim dark header (yaml/json SegmentedControl on the
-// left, copy button on the right) above a borderless CodeHighlight using the
-// Stack Overflow Light syntax theme.
+// left when there is more than one language, copy button on the right) above
+// a borderless CodeHighlight whose syntax colors come from the .theme-code
+// class in code-themes.css.
 //
-//   languages        - non-empty array containing "yaml", "json", or both,
-//                      in the order tabs should appear. Single-language
-//                      sections still get the same header so the language is
-//                      labeled (Mantine renders a single-item SegmentedControl
-//                      as a non-interactive label).
-//   defaultLanguage  - which tab is selected first. Must be one of `languages`.
-function CodeSection({ title, data, languages, defaultLanguage, loading }) {
+//   languages  - non-empty ordered array containing "yaml", "json", or both.
+//                The first entry is the initially-selected tab. Single-
+//                language sections render with no toggle (just the copy
+//                button), since the language is implicit.
+//   error      - if true and data is missing, render a "Failed to load"
+//                message instead of the perpetual skeleton.
+function CodeSection({ title, data, languages, loading, error = false }) {
   const codes = useMemo(() => {
-    const parsed = parseSection(data) ?? {};
+    const parsed = data ?? {};
     return {
       yaml: yaml.stringify(parsed),
       json: stringifyCompactArrays(parsed),
     };
   }, [data]);
-  const [lang, setLang] = useState(defaultLanguage);
-  const isLoading = loading || data == null;
+  const [lang, setLang] = useState(languages[0]);
+  const showError = error && data == null && !loading;
+  const showSkeleton = !showError && (loading || data == null);
+  const multipleLanguages = languages.length > 1;
   return (
     <Stack gap="xs">
       <Text style={SECTION_TITLE_STYLE}>{title}</Text>
-      {isLoading ? (
-        <GenericSectionSkeleton />
-      ) : (
+      {showSkeleton && <GenericSectionSkeleton />}
+      {showError && (
+        <Alert color="red" variant="light">
+          Failed to load.
+        </Alert>
+      )}
+      {!showSkeleton && !showError && (
         <Paper
           withBorder
           radius="sm"
           className="theme-code"
           style={{ overflow: "hidden" }}
         >
-          <Group justify="space-between" align="center" px="xs" py={6} style={DARK_HEADER_STYLE}>
-            {languages.length > 1 ? (
+          <Group
+            justify={multipleLanguages ? "space-between" : "flex-end"}
+            align="center"
+            px="xs"
+            py={6}
+            style={DARK_HEADER_STYLE}
+          >
+            {multipleLanguages && (
               <SegmentedControl
                 size="xs"
                 value={lang}
                 onChange={setLang}
+                aria-label="Code format"
                 classNames={{
                   root: "dark-pill-toggle-root",
                   indicator: "dark-pill-toggle-indicator",
@@ -148,8 +158,6 @@ function CodeSection({ title, data, languages, defaultLanguage, loading }) {
                 }}
                 data={languages.map((l) => ({ label: l, value: l }))}
               />
-            ) : (
-              <div />
             )}
             <CopyButton value={codes[lang]} timeout={1500}>
               {({ copied, copy }) => (
@@ -178,6 +186,7 @@ export default function App() {
   const [metrics, setMetrics] = useState(null);
   const [resources, setResources] = useState(null);
   const [edgeConfig, setEdgeConfig] = useState(null);
+  const [edgeConfigError, setEdgeConfigError] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const intervalRef = useRef(null);
@@ -207,9 +216,14 @@ export default function App() {
 
     try {
       const res = await fetch("/edge-config");
-      if (res.ok) setEdgeConfig(await res.json());
+      if (res.ok) {
+        setEdgeConfig(await res.json());
+        setEdgeConfigError(false);
+      } else {
+        setEdgeConfigError(true);
+      }
     } catch {
-      // Edge config is optional
+      setEdgeConfigError(true);
     }
   }, []);
 
@@ -287,38 +301,34 @@ export default function App() {
           <CodeSection
             title="Device Information"
             data={metrics?.device_info}
-            languages={["json"]}
-            defaultLanguage="json"
+            languages={JSON_ONLY}
             loading={loading}
           />
 
           <CodeSection
             title="Configuration"
             data={edgeConfig}
-            languages={["yaml", "json"]}
-            defaultLanguage="yaml"
+            languages={YAML_OR_JSON}
             loading={loading}
+            error={edgeConfigError}
           />
 
           <CodeSection
             title="Activity Metrics"
             data={metrics?.activity_metrics}
-            languages={["json"]}
-            defaultLanguage="json"
+            languages={JSON_ONLY}
             loading={loading}
           />
           <CodeSection
             title="Kubernetes Stats"
             data={metrics?.k3s_stats}
-            languages={["json"]}
-            defaultLanguage="json"
+            languages={JSON_ONLY}
             loading={loading}
           />
           <CodeSection
             title="Failed Escalations"
             data={metrics?.failed_escalations}
-            languages={["json"]}
-            defaultLanguage="json"
+            languages={JSON_ONLY}
             loading={loading}
           />
         </Stack>

--- a/app/status_monitor/frontend/src/App.jsx
+++ b/app/status_monitor/frontend/src/App.jsx
@@ -70,6 +70,13 @@ const SECTION_TITLE_STYLE = { fontSize: "1.25em", fontWeight: 500, color: "#1F1D
 const JSON_ONLY = ["json"];
 const YAML_OR_JSON = ["yaml", "json"];
 
+// Serializer for each supported CodeSection language. Each entry must accept
+// the parsed payload object and return a string.
+const LANGUAGE_SERIALIZERS = {
+  yaml: (parsed) => yaml.stringify(parsed),
+  json: (parsed) => stringifyCompactArrays(parsed),
+};
+
 function GenericSectionSkeleton() {
   return (
     <Paper shadow="xs" p="md" radius="sm">
@@ -111,13 +118,22 @@ function CheckIcon() {
 //   error      - if true and data is missing, render a "Failed to load"
 //                message instead of the perpetual skeleton.
 function CodeSection({ title, data, languages, loading, error = false }) {
+  // Each serializer is wrapped individually so a failure in one language tab
+  // (e.g. an exotic value yaml.stringify can't handle) doesn't take down the
+  // others. Only the requested languages are computed -- skipping the unused
+  // serializer for single-language sections.
   const codes = useMemo(() => {
     const parsed = data ?? {};
-    return {
-      yaml: yaml.stringify(parsed),
-      json: stringifyCompactArrays(parsed),
-    };
-  }, [data]);
+    return Object.fromEntries(
+      languages.map((l) => {
+        try {
+          return [l, LANGUAGE_SERIALIZERS[l](parsed)];
+        } catch (e) {
+          return [l, `// Failed to render as ${l}: ${e.message}`];
+        }
+      })
+    );
+  }, [data, languages]);
   const [lang, setLang] = useState(languages[0]);
   const showError = error && data == null && !loading;
   const showSkeleton = !showError && (loading || data == null);

--- a/app/status_monitor/frontend/src/App.jsx
+++ b/app/status_monitor/frontend/src/App.jsx
@@ -102,8 +102,6 @@ function CheckIcon() {
   );
 }
 
-const CODE_BG = "#f6f6f6";
-
 // Single code-block widget used for every "view this dict as code" section on
 // the page. Renders a slim dark header (yaml/json SegmentedControl on the
 // left, copy button on the right) above a borderless CodeHighlight using the
@@ -134,8 +132,8 @@ function CodeSection({ title, data, languages, defaultLanguage, loading }) {
         <Paper
           withBorder
           radius="sm"
-          className="theme-stackoverflow-light"
-          style={{ overflow: "hidden", background: CODE_BG }}
+          className="theme-code"
+          style={{ overflow: "hidden" }}
         >
           <Group justify="space-between" align="center" px="xs" py={6} style={DARK_HEADER_STYLE}>
             {languages.length > 1 ? (
@@ -169,7 +167,7 @@ function CodeSection({ title, data, languages, defaultLanguage, loading }) {
               )}
             </CopyButton>
           </Group>
-          <CodeHighlight code={codes[lang]} language={lang} withCopyButton={false} background={CODE_BG} />
+          <CodeHighlight code={codes[lang]} language={lang} withCopyButton={false} />
         </Paper>
       )}
     </Stack>

--- a/app/status_monitor/frontend/src/App.jsx
+++ b/app/status_monitor/frontend/src/App.jsx
@@ -37,6 +37,35 @@ const parseSection = (section) => {
   return parsed;
 };
 
+// Pretty-print JSON like JSON.stringify(value, null, indent), but keep arrays
+// of pure primitives on a single line so e.g. histogram counts don't take up
+// an entire vertical column.
+const stringifyCompactArrays = (value, indent = 2) => {
+  const pad = (depth) => " ".repeat(depth * indent);
+  const isPrimitive = (v) =>
+    v === null || ["string", "number", "boolean"].includes(typeof v);
+  const fmt = (v, depth) => {
+    if (Array.isArray(v) && v.every(isPrimitive)) {
+      return `[${v.map((x) => JSON.stringify(x)).join(", ")}]`;
+    }
+    if (Array.isArray(v)) {
+      if (v.length === 0) return "[]";
+      const inner = v.map((x) => pad(depth + 1) + fmt(x, depth + 1));
+      return `[\n${inner.join(",\n")}\n${pad(depth)}]`;
+    }
+    if (v && typeof v === "object") {
+      const entries = Object.entries(v);
+      if (entries.length === 0) return "{}";
+      const lines = entries.map(
+        ([k, x]) => `${pad(depth + 1)}${JSON.stringify(k)}: ${fmt(x, depth + 1)}`
+      );
+      return `{\n${lines.join(",\n")}\n${pad(depth)}}`;
+    }
+    return JSON.stringify(v);
+  };
+  return fmt(value, 0);
+};
+
 const SECTION_TITLE_STYLE = { fontSize: "1.25em", fontWeight: 500, color: "#1F1D23" };
 
 function GenericSectionSkeleton() {
@@ -52,7 +81,7 @@ function GenericSectionSkeleton() {
 }
 
 function JsonSection({ title, data, loading }) {
-  const code = data ? JSON.stringify(parseSection(data), null, 2) : "";
+  const code = data ? stringifyCompactArrays(parseSection(data)) : "";
   return (
     <Stack gap="xs">
       <Text style={SECTION_TITLE_STYLE}>{title}</Text>
@@ -75,6 +104,7 @@ function JsonSection({ title, data, loading }) {
 export default function App() {
   const [metrics, setMetrics] = useState(null);
   const [resources, setResources] = useState(null);
+  const [edgeConfig, setEdgeConfig] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const intervalRef = useRef(null);
@@ -100,6 +130,13 @@ export default function App() {
       if (res.ok) setResources(await res.json());
     } catch {
       // Resource data is optional
+    }
+
+    try {
+      const res = await fetch("/edge-config");
+      if (res.ok) setEdgeConfig(await res.json());
+    } catch {
+      // Edge config is optional
     }
   }, []);
 
@@ -164,8 +201,6 @@ export default function App() {
         )}
 
         <Stack gap="xl">
-          <JsonSection title="Device Information" data={metrics?.device_info} loading={loading} />
-
           <Stack gap="xs">
             <Text style={SECTION_TITLE_STYLE}>Detector Details</Text>
             <DetectorDetails details={detectorDetails} loading={loading} />
@@ -175,6 +210,10 @@ export default function App() {
             <Text style={SECTION_TITLE_STYLE}>Resource Usage by Detector</Text>
             <ResourceUsage resourceData={resources} detectorDetails={detectorDetails} loading={loading} />
           </Stack>
+
+          <JsonSection title="Device Information" data={metrics?.device_info} loading={loading} />
+
+          <JsonSection title="Edge Endpoint Configuration" data={edgeConfig} loading={loading} />
 
           <JsonSection title="Activity Metrics" data={metrics?.activity_metrics} loading={loading} />
           <JsonSection title="Kubernetes Stats" data={metrics?.k3s_stats} loading={loading} />

--- a/app/status_monitor/frontend/src/App.jsx
+++ b/app/status_monitor/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import {
   Container,
   Title,
@@ -9,10 +9,16 @@ import {
   Stack,
   Paper,
   Skeleton,
+  SegmentedControl,
+  CopyButton,
+  ActionIcon,
+  Tooltip,
 } from "@mantine/core";
 import { CodeHighlight } from "@mantine/code-highlight";
+import yaml from "yaml";
 import DetectorDetails from "./components/DetectorDetails";
 import ResourceUsage from "./components/ResourceUsage";
+import { DARK_HEADER_STYLE } from "./sharedStyles";
 
 // Faster polling in dev is helpful when iterating, slow down polling in prod
 const REFRESH_MS = import.meta.env.DEV ? 1_000 : 10_000;
@@ -80,22 +86,91 @@ function GenericSectionSkeleton() {
   );
 }
 
-function JsonSection({ title, data, loading }) {
-  const code = data ? stringifyCompactArrays(parseSection(data)) : "";
+function CopyIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+function CheckIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+const CODE_BG = "#f6f6f6";
+
+// Single code-block widget used for every "view this dict as code" section on
+// the page. Renders a slim dark header (yaml/json SegmentedControl on the
+// left, copy button on the right) above a borderless CodeHighlight using the
+// Stack Overflow Light syntax theme.
+//
+//   languages        - non-empty array containing "yaml", "json", or both,
+//                      in the order tabs should appear. Single-language
+//                      sections still get the same header so the language is
+//                      labeled (Mantine renders a single-item SegmentedControl
+//                      as a non-interactive label).
+//   defaultLanguage  - which tab is selected first. Must be one of `languages`.
+function CodeSection({ title, data, languages, defaultLanguage, loading }) {
+  const codes = useMemo(() => {
+    const parsed = parseSection(data) ?? {};
+    return {
+      yaml: yaml.stringify(parsed),
+      json: stringifyCompactArrays(parsed),
+    };
+  }, [data]);
+  const [lang, setLang] = useState(defaultLanguage);
+  const isLoading = loading || data == null;
   return (
     <Stack gap="xs">
       <Text style={SECTION_TITLE_STYLE}>{title}</Text>
-      {loading ? (
+      {isLoading ? (
         <GenericSectionSkeleton />
       ) : (
-        <CodeHighlight
-          code={code}
-          language="json"
-          copyLabel="Copy"
-          copiedLabel="Copied"
-          radius="sm"
+        <Paper
           withBorder
-        />
+          radius="sm"
+          className="theme-stackoverflow-light"
+          style={{ overflow: "hidden", background: CODE_BG }}
+        >
+          <Group justify="space-between" align="center" px="xs" py={6} style={DARK_HEADER_STYLE}>
+            {languages.length > 1 ? (
+              <SegmentedControl
+                size="xs"
+                value={lang}
+                onChange={setLang}
+                classNames={{
+                  root: "dark-pill-toggle-root",
+                  indicator: "dark-pill-toggle-indicator",
+                  label: "dark-pill-toggle-label",
+                }}
+                data={languages.map((l) => ({ label: l, value: l }))}
+              />
+            ) : (
+              <div />
+            )}
+            <CopyButton value={codes[lang]} timeout={1500}>
+              {({ copied, copy }) => (
+                <Tooltip label={copied ? "Copied" : "Copy"} withArrow position="left">
+                  <ActionIcon
+                    variant="subtle"
+                    size="sm"
+                    onClick={copy}
+                    aria-label="Copy"
+                    style={{ color: "rgba(255,255,255,0.7)" }}
+                  >
+                    {copied ? <CheckIcon /> : <CopyIcon />}
+                  </ActionIcon>
+                </Tooltip>
+              )}
+            </CopyButton>
+          </Group>
+          <CodeHighlight code={codes[lang]} language={lang} withCopyButton={false} background={CODE_BG} />
+        </Paper>
       )}
     </Stack>
   );
@@ -211,13 +286,43 @@ export default function App() {
             <ResourceUsage resourceData={resources} detectorDetails={detectorDetails} loading={loading} />
           </Stack>
 
-          <JsonSection title="Device Information" data={metrics?.device_info} loading={loading} />
+          <CodeSection
+            title="Device Information"
+            data={metrics?.device_info}
+            languages={["json"]}
+            defaultLanguage="json"
+            loading={loading}
+          />
 
-          <JsonSection title="Edge Endpoint Configuration" data={edgeConfig} loading={loading} />
+          <CodeSection
+            title="Configuration"
+            data={edgeConfig}
+            languages={["yaml", "json"]}
+            defaultLanguage="yaml"
+            loading={loading}
+          />
 
-          <JsonSection title="Activity Metrics" data={metrics?.activity_metrics} loading={loading} />
-          <JsonSection title="Kubernetes Stats" data={metrics?.k3s_stats} loading={loading} />
-          <JsonSection title="Failed Escalations" data={metrics?.failed_escalations} loading={loading} />
+          <CodeSection
+            title="Activity Metrics"
+            data={metrics?.activity_metrics}
+            languages={["json"]}
+            defaultLanguage="json"
+            loading={loading}
+          />
+          <CodeSection
+            title="Kubernetes Stats"
+            data={metrics?.k3s_stats}
+            languages={["json"]}
+            defaultLanguage="json"
+            loading={loading}
+          />
+          <CodeSection
+            title="Failed Escalations"
+            data={metrics?.failed_escalations}
+            languages={["json"]}
+            defaultLanguage="json"
+            loading={loading}
+          />
         </Stack>
       </Container>
     </>

--- a/app/status_monitor/frontend/src/App.jsx
+++ b/app/status_monitor/frontend/src/App.jsx
@@ -18,6 +18,7 @@ import { CodeHighlight } from "@mantine/code-highlight";
 import yaml from "yaml";
 import DetectorDetails from "./components/DetectorDetails";
 import ResourceUsage from "./components/ResourceUsage";
+import CollapsibleSection from "./components/CollapsibleSection";
 import { DARK_HEADER_STYLE } from "./sharedStyles";
 
 // Faster polling in dev is helpful when iterating, slow down polling in prod
@@ -32,6 +33,22 @@ const parseIfJson = (value) => {
     }
   }
   return value;
+};
+
+// Walk a section's top-level keys and JSON.parse any string value that
+// happens to be valid JSON. Some metrics fields are deliberately stringified
+// on the backend (via json.dumps) to keep OpenSearch from exploding nested
+// objects into thousands of indexed fields. For human display we want to
+// undo that so the data renders as nested JSON instead of a wall of
+// backslash-escaped quotes. Strings that aren't valid JSON (e.g. plain
+// timestamps, Python repr lists) are passed through unchanged.
+const rehydrateSection = (section) => {
+  if (!section || typeof section !== "object") return section;
+  const parsed = { ...section };
+  for (const [key, value] of Object.entries(parsed)) {
+    parsed[key] = parseIfJson(value);
+  }
+  return parsed;
 };
 
 // Pretty-print JSON like JSON.stringify(value, null, indent), but keep arrays
@@ -62,8 +79,6 @@ const stringifyCompactArrays = (value, indent = 2) => {
   };
   return fmt(value, 0);
 };
-
-const SECTION_TITLE_STYLE = { fontSize: "1.25em", fontWeight: 500, color: "#1F1D23" };
 
 // Stable references for CodeSection's `languages` prop so memoization isn't
 // invalidated by fresh array literals on every render.
@@ -105,11 +120,12 @@ function CheckIcon() {
   );
 }
 
-// Single code-block widget used for every "view this dict as code" section on
-// the page. Renders a slim dark header (yaml/json SegmentedControl on the
-// left when there is more than one language, copy button on the right) above
-// a borderless CodeHighlight whose syntax colors come from the .theme-code
-// class in code-themes.css.
+// Body widget for "view this dict as code" sections. Renders a slim dark
+// header (yaml/json SegmentedControl on the left when there is more than one
+// language, copy button on the right) above a borderless CodeHighlight whose
+// syntax colors come from the .theme-code class in code-themes.css. The
+// section title and surrounding chrome (collapse trigger, gap) are owned by
+// the wrapping CollapsibleSection.
 //
 //   languages  - non-empty ordered array containing "yaml", "json", or both.
 //                The first entry is the initially-selected tab. Single-
@@ -117,13 +133,17 @@ function CheckIcon() {
 //                button), since the language is implicit.
 //   error      - if true and data is missing, render a "Failed to load"
 //                message instead of the perpetual skeleton.
-function CodeSection({ title, data, languages, loading, error = false }) {
+//   rehydrate  - if true, JSON.parse top-level string values that look like
+//                JSON before serializing. Use this for sections whose backend
+//                deliberately stringifies subfields to dodge OpenSearch field
+//                explosion (e.g. Kubernetes Stats, Activity Metrics).
+function CodeSection({ data, languages, loading, error = false, rehydrate = false }) {
   // Each serializer is wrapped individually so a failure in one language tab
   // (e.g. an exotic value yaml.stringify can't handle) doesn't take down the
   // others. Only the requested languages are computed -- skipping the unused
   // serializer for single-language sections.
   const codes = useMemo(() => {
-    const parsed = data ?? {};
+    const parsed = (rehydrate ? rehydrateSection(data) : data) ?? {};
     return Object.fromEntries(
       languages.map((l) => {
         try {
@@ -133,68 +153,65 @@ function CodeSection({ title, data, languages, loading, error = false }) {
         }
       })
     );
-  }, [data, languages]);
+  }, [data, languages, rehydrate]);
   const [lang, setLang] = useState(languages[0]);
   const showError = error && data == null && !loading;
   const showSkeleton = !showError && (loading || data == null);
   const multipleLanguages = languages.length > 1;
+  if (showSkeleton) return <GenericSectionSkeleton />;
+  if (showError) {
+    return (
+      <Alert color="red" variant="light">
+        Failed to load.
+      </Alert>
+    );
+  }
   return (
-    <Stack gap="xs">
-      <Text style={SECTION_TITLE_STYLE}>{title}</Text>
-      {showSkeleton && <GenericSectionSkeleton />}
-      {showError && (
-        <Alert color="red" variant="light">
-          Failed to load.
-        </Alert>
-      )}
-      {!showSkeleton && !showError && (
-        <Paper
-          withBorder
-          radius="sm"
-          className="theme-code"
-          style={{ overflow: "hidden" }}
-        >
-          <Group
-            justify={multipleLanguages ? "space-between" : "flex-end"}
-            align="center"
-            px="xs"
-            py={6}
-            style={DARK_HEADER_STYLE}
-          >
-            {multipleLanguages && (
-              <SegmentedControl
-                size="xs"
-                value={lang}
-                onChange={setLang}
-                aria-label="Code format"
-                classNames={{
-                  root: "dark-pill-toggle-root",
-                  indicator: "dark-pill-toggle-indicator",
-                  label: "dark-pill-toggle-label",
-                }}
-                data={languages.map((l) => ({ label: l, value: l }))}
-              />
-            )}
-            <CopyButton value={codes[lang]} timeout={1500}>
-              {({ copied, copy }) => (
-                <Tooltip label={copied ? "Copied" : "Copy"} withArrow position="left">
-                  <ActionIcon
-                    variant="subtle"
-                    size="sm"
-                    onClick={copy}
-                    aria-label="Copy"
-                    style={{ color: "rgba(255,255,255,0.7)" }}
-                  >
-                    {copied ? <CheckIcon /> : <CopyIcon />}
-                  </ActionIcon>
-                </Tooltip>
-              )}
-            </CopyButton>
-          </Group>
-          <CodeHighlight code={codes[lang]} language={lang} withCopyButton={false} />
-        </Paper>
-      )}
-    </Stack>
+    <Paper
+      withBorder
+      radius="sm"
+      className="theme-code"
+      style={{ overflow: "hidden" }}
+    >
+      <Group
+        justify={multipleLanguages ? "space-between" : "flex-end"}
+        align="center"
+        px="xs"
+        py={6}
+        style={DARK_HEADER_STYLE}
+      >
+        {multipleLanguages && (
+          <SegmentedControl
+            size="xs"
+            value={lang}
+            onChange={setLang}
+            aria-label="Code format"
+            classNames={{
+              root: "dark-pill-toggle-root",
+              indicator: "dark-pill-toggle-indicator",
+              label: "dark-pill-toggle-label",
+            }}
+            data={languages.map((l) => ({ label: l, value: l }))}
+          />
+        )}
+        <CopyButton value={codes[lang]} timeout={1500}>
+          {({ copied, copy }) => (
+            <Tooltip label={copied ? "Copied" : "Copy"} withArrow position="left">
+              <ActionIcon
+                variant="subtle"
+                size="sm"
+                onClick={copy}
+                aria-label="Copy"
+                style={{ color: "rgba(255,255,255,0.7)" }}
+              >
+                {copied ? <CheckIcon /> : <CopyIcon />}
+              </ActionIcon>
+            </Tooltip>
+          )}
+        </CopyButton>
+      </Group>
+      <CodeHighlight code={codes[lang]} language={lang} withCopyButton={false} />
+    </Paper>
   );
 }
 
@@ -304,49 +321,38 @@ export default function App() {
         )}
 
         <Stack gap="xl">
-          <Stack gap="xs">
-            <Text style={SECTION_TITLE_STYLE}>Detector Details</Text>
+          <CollapsibleSection title="Detector Details">
             <DetectorDetails details={detectorDetails} loading={loading} />
-          </Stack>
+          </CollapsibleSection>
 
-          <Stack gap="xs">
-            <Text style={SECTION_TITLE_STYLE}>Resource Usage by Detector</Text>
+          <CollapsibleSection title="Resource Usage by Detector">
             <ResourceUsage resourceData={resources} detectorDetails={detectorDetails} loading={loading} />
-          </Stack>
+          </CollapsibleSection>
 
-          <CodeSection
-            title="Device Information"
-            data={metrics?.device_info}
-            languages={JSON_ONLY}
-            loading={loading}
-          />
+          <CollapsibleSection title="Device Information">
+            <CodeSection data={metrics?.device_info} languages={JSON_ONLY} loading={loading} />
+          </CollapsibleSection>
 
-          <CodeSection
-            title="Configuration"
-            data={edgeConfig}
-            languages={YAML_OR_JSON}
-            loading={loading}
-            error={edgeConfigError}
-          />
+          <CollapsibleSection title="Configuration">
+            <CodeSection
+              data={edgeConfig}
+              languages={YAML_OR_JSON}
+              loading={loading}
+              error={edgeConfigError}
+            />
+          </CollapsibleSection>
 
-          <CodeSection
-            title="Activity Metrics"
-            data={metrics?.activity_metrics}
-            languages={JSON_ONLY}
-            loading={loading}
-          />
-          <CodeSection
-            title="Kubernetes Stats"
-            data={metrics?.k3s_stats}
-            languages={JSON_ONLY}
-            loading={loading}
-          />
-          <CodeSection
-            title="Failed Escalations"
-            data={metrics?.failed_escalations}
-            languages={JSON_ONLY}
-            loading={loading}
-          />
+          <CollapsibleSection title="Activity Metrics">
+            <CodeSection data={metrics?.activity_metrics} languages={JSON_ONLY} loading={loading} rehydrate />
+          </CollapsibleSection>
+
+          <CollapsibleSection title="Kubernetes Stats">
+            <CodeSection data={metrics?.k3s_stats} languages={JSON_ONLY} loading={loading} rehydrate />
+          </CollapsibleSection>
+
+          <CollapsibleSection title="Failed Escalations">
+            <CodeSection data={metrics?.failed_escalations} languages={JSON_ONLY} loading={loading} />
+          </CollapsibleSection>
         </Stack>
       </Container>
     </>

--- a/app/status_monitor/frontend/src/code-themes.css
+++ b/app/status_monitor/frontend/src/code-themes.css
@@ -1,9 +1,12 @@
 /*
  * Syntax highlighting theme for all CodeSection blocks on the status page.
  *
- * Color rules are adapted from the highlight.js light theme. The wrapper
- * class .theme-code scopes every rule so the theme only applies to opted-in
- * code blocks and never bleeds into the rest of the page.
+ * Color rules are adapted from the highlight.js light theme, plus one
+ * deliberate addition: `#6f42c1` (purple) on `.hljs-literal` so JSON / YAML
+ * booleans and `null` are visually distinct from numbers. Don't "restore"
+ * that color to the upstream value -- the divergence is intentional. The
+ * wrapper class .theme-code scopes every rule so the theme only applies to
+ * opted-in code blocks and never bleeds into the rest of the page.
  *
  * --ch-background is the Mantine CodeHighlight CSS variable that controls the
  * background of both the container and the pre element.

--- a/app/status_monitor/frontend/src/code-themes.css
+++ b/app/status_monitor/frontend/src/code-themes.css
@@ -38,8 +38,14 @@
 .theme-code .hljs-meta,
 .theme-code .hljs-selector-pseudo { color: #015692; }
 .theme-code .hljs-built_in,
-.theme-code .hljs-title,
-.theme-code .hljs-literal { color: #b75501; }
+.theme-code .hljs-title { color: #b75501; }
+/* JSON / YAML booleans (true/false) and null. Split off from numbers so each
+   value type renders in a distinct color. The nested `.hljs-keyword` selector
+   is needed because the JSON grammar wraps booleans/null as
+   `<span class="hljs-literal"><span class="hljs-keyword">true</span></span>`,
+   so without it the inner span wins and inherits the blue keyword color. */
+.theme-code .hljs-literal,
+.theme-code .hljs-literal .hljs-keyword { color: #6f42c1; }
 .theme-code .hljs-bullet,
 .theme-code .hljs-code { color: #535a60; }
 .theme-code .hljs-meta .hljs-string { color: #54790d; }

--- a/app/status_monitor/frontend/src/code-themes.css
+++ b/app/status_monitor/frontend/src/code-themes.css
@@ -1,47 +1,49 @@
 /*
- * Scoped highlight.js theme for code-block sections (CodeSection).
+ * Syntax highlighting theme for all CodeSection blocks on the status page.
  *
- * Rules below are ported verbatim from highlight.js/styles/stackoverflow-light.css
- * and prefixed with .theme-stackoverflow-light so the theme only applies to
- * opted-in code blocks (and never bleeds into the rest of the page).
+ * Color rules are adapted from the highlight.js light theme. The wrapper
+ * class .theme-code scopes every rule so the theme only applies to opted-in
+ * code blocks and never bleeds into the rest of the page.
+ *
+ * --ch-background is the Mantine CodeHighlight CSS variable that controls the
+ * background of both the container and the pre element.
  */
-
-.theme-stackoverflow-light .hljs {
-  color: #2f3337;
-  background: #f6f6f6;
+.theme-code {
+  --ch-background: #ffffff;
 }
-.theme-stackoverflow-light .hljs-subst { color: #2f3337; }
-.theme-stackoverflow-light .hljs-comment { color: #656e77; }
-.theme-stackoverflow-light .hljs-keyword,
-.theme-stackoverflow-light .hljs-selector-tag,
-.theme-stackoverflow-light .hljs-meta .hljs-keyword,
-.theme-stackoverflow-light .hljs-doctag,
-.theme-stackoverflow-light .hljs-section { color: #015692; }
-.theme-stackoverflow-light .hljs-attr { color: #015692; }
-.theme-stackoverflow-light .hljs-attribute { color: #803378; }
-.theme-stackoverflow-light .hljs-name,
-.theme-stackoverflow-light .hljs-type,
-.theme-stackoverflow-light .hljs-number,
-.theme-stackoverflow-light .hljs-selector-id,
-.theme-stackoverflow-light .hljs-quote,
-.theme-stackoverflow-light .hljs-template-tag { color: #b75501; }
-.theme-stackoverflow-light .hljs-selector-class { color: #015692; }
-.theme-stackoverflow-light .hljs-string,
-.theme-stackoverflow-light .hljs-regexp,
-.theme-stackoverflow-light .hljs-symbol,
-.theme-stackoverflow-light .hljs-variable,
-.theme-stackoverflow-light .hljs-template-variable,
-.theme-stackoverflow-light .hljs-link,
-.theme-stackoverflow-light .hljs-selector-attr { color: #54790d; }
-.theme-stackoverflow-light .hljs-meta,
-.theme-stackoverflow-light .hljs-selector-pseudo { color: #015692; }
-.theme-stackoverflow-light .hljs-built_in,
-.theme-stackoverflow-light .hljs-title,
-.theme-stackoverflow-light .hljs-literal { color: #b75501; }
-.theme-stackoverflow-light .hljs-bullet,
-.theme-stackoverflow-light .hljs-code { color: #535a60; }
-.theme-stackoverflow-light .hljs-meta .hljs-string { color: #54790d; }
-.theme-stackoverflow-light .hljs-deletion { color: #c02d2e; }
-.theme-stackoverflow-light .hljs-addition { color: #2f6f44; }
-.theme-stackoverflow-light .hljs-emphasis { font-style: italic; }
-.theme-stackoverflow-light .hljs-strong { font-weight: bold; }
+.theme-code .hljs { color: #2f3337; }
+.theme-code .hljs-subst { color: #2f3337; }
+.theme-code .hljs-comment { color: #656e77; }
+.theme-code .hljs-keyword,
+.theme-code .hljs-selector-tag,
+.theme-code .hljs-meta .hljs-keyword,
+.theme-code .hljs-doctag,
+.theme-code .hljs-section { color: #015692; }
+.theme-code .hljs-attr { color: #015692; }
+.theme-code .hljs-attribute { color: #803378; }
+.theme-code .hljs-name,
+.theme-code .hljs-type,
+.theme-code .hljs-number,
+.theme-code .hljs-selector-id,
+.theme-code .hljs-quote,
+.theme-code .hljs-template-tag { color: #b75501; }
+.theme-code .hljs-selector-class { color: #015692; }
+.theme-code .hljs-string,
+.theme-code .hljs-regexp,
+.theme-code .hljs-symbol,
+.theme-code .hljs-variable,
+.theme-code .hljs-template-variable,
+.theme-code .hljs-link,
+.theme-code .hljs-selector-attr { color: #54790d; }
+.theme-code .hljs-meta,
+.theme-code .hljs-selector-pseudo { color: #015692; }
+.theme-code .hljs-built_in,
+.theme-code .hljs-title,
+.theme-code .hljs-literal { color: #b75501; }
+.theme-code .hljs-bullet,
+.theme-code .hljs-code { color: #535a60; }
+.theme-code .hljs-meta .hljs-string { color: #54790d; }
+.theme-code .hljs-deletion { color: #c02d2e; }
+.theme-code .hljs-addition { color: #2f6f44; }
+.theme-code .hljs-emphasis { font-style: italic; }
+.theme-code .hljs-strong { font-weight: bold; }

--- a/app/status_monitor/frontend/src/code-themes.css
+++ b/app/status_monitor/frontend/src/code-themes.css
@@ -1,0 +1,47 @@
+/*
+ * Scoped highlight.js theme for code-block sections (CodeSection).
+ *
+ * Rules below are ported verbatim from highlight.js/styles/stackoverflow-light.css
+ * and prefixed with .theme-stackoverflow-light so the theme only applies to
+ * opted-in code blocks (and never bleeds into the rest of the page).
+ */
+
+.theme-stackoverflow-light .hljs {
+  color: #2f3337;
+  background: #f6f6f6;
+}
+.theme-stackoverflow-light .hljs-subst { color: #2f3337; }
+.theme-stackoverflow-light .hljs-comment { color: #656e77; }
+.theme-stackoverflow-light .hljs-keyword,
+.theme-stackoverflow-light .hljs-selector-tag,
+.theme-stackoverflow-light .hljs-meta .hljs-keyword,
+.theme-stackoverflow-light .hljs-doctag,
+.theme-stackoverflow-light .hljs-section { color: #015692; }
+.theme-stackoverflow-light .hljs-attr { color: #015692; }
+.theme-stackoverflow-light .hljs-attribute { color: #803378; }
+.theme-stackoverflow-light .hljs-name,
+.theme-stackoverflow-light .hljs-type,
+.theme-stackoverflow-light .hljs-number,
+.theme-stackoverflow-light .hljs-selector-id,
+.theme-stackoverflow-light .hljs-quote,
+.theme-stackoverflow-light .hljs-template-tag { color: #b75501; }
+.theme-stackoverflow-light .hljs-selector-class { color: #015692; }
+.theme-stackoverflow-light .hljs-string,
+.theme-stackoverflow-light .hljs-regexp,
+.theme-stackoverflow-light .hljs-symbol,
+.theme-stackoverflow-light .hljs-variable,
+.theme-stackoverflow-light .hljs-template-variable,
+.theme-stackoverflow-light .hljs-link,
+.theme-stackoverflow-light .hljs-selector-attr { color: #54790d; }
+.theme-stackoverflow-light .hljs-meta,
+.theme-stackoverflow-light .hljs-selector-pseudo { color: #015692; }
+.theme-stackoverflow-light .hljs-built_in,
+.theme-stackoverflow-light .hljs-title,
+.theme-stackoverflow-light .hljs-literal { color: #b75501; }
+.theme-stackoverflow-light .hljs-bullet,
+.theme-stackoverflow-light .hljs-code { color: #535a60; }
+.theme-stackoverflow-light .hljs-meta .hljs-string { color: #54790d; }
+.theme-stackoverflow-light .hljs-deletion { color: #c02d2e; }
+.theme-stackoverflow-light .hljs-addition { color: #2f6f44; }
+.theme-stackoverflow-light .hljs-emphasis { font-style: italic; }
+.theme-stackoverflow-light .hljs-strong { font-weight: bold; }

--- a/app/status_monitor/frontend/src/components/CollapsibleSection.jsx
+++ b/app/status_monitor/frontend/src/components/CollapsibleSection.jsx
@@ -8,9 +8,15 @@ import { SECTION_TITLE_STYLE } from "../sharedStyles";
 // feedback for the open/closed state. Per-instance state, so each section
 // remembers its own open/closed independently across the polling refresh.
 //
+// Note: Mantine's <Collapse> hides children but does NOT unmount them, so
+// any expensive work in the body (e.g. CodeSection's serializer useMemo)
+// continues to run on every poll while the section is collapsed. Trivial
+// for our payloads; revisit if a future child becomes truly expensive.
+//
 //   title       - heading text shown next to the chevron.
 //   defaultOpen - initial open state. Defaults to true; set false for
-//                 noisy / rarely-interesting sections.
+//                 noisy / rarely-interesting sections. Only used on first
+//                 mount; later changes to the prop are ignored.
 //   children    - section body. Rendered inside the Collapse, with the
 //                 standard "xs" gap between title row and body.
 function ChevronIcon({ open }) {

--- a/app/status_monitor/frontend/src/components/CollapsibleSection.jsx
+++ b/app/status_monitor/frontend/src/components/CollapsibleSection.jsx
@@ -1,0 +1,60 @@
+import { useState, useId } from "react";
+import { Stack, Group, Text, UnstyledButton, Collapse } from "@mantine/core";
+import { SECTION_TITLE_STYLE } from "../sharedStyles";
+
+// Standard wrapper for every top-level section on the status page. Renders a
+// click-to-toggle title row (chevron + title text) above a Mantine Collapse
+// containing the section body. The chevron rotates 90 degrees as visual
+// feedback for the open/closed state. Per-instance state, so each section
+// remembers its own open/closed independently across the polling refresh.
+//
+//   title       - heading text shown next to the chevron.
+//   defaultOpen - initial open state. Defaults to true; set false for
+//                 noisy / rarely-interesting sections.
+//   children    - section body. Rendered inside the Collapse, with the
+//                 standard "xs" gap between title row and body.
+function ChevronIcon({ open }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{
+        transform: open ? "rotate(90deg)" : "rotate(0deg)",
+        transition: "transform 150ms ease",
+        flexShrink: 0,
+        color: "#666",
+      }}
+    >
+      <polyline points="9 6 15 12 9 18" />
+    </svg>
+  );
+}
+
+export default function CollapsibleSection({ title, children, defaultOpen = true }) {
+  const [open, setOpen] = useState(defaultOpen);
+  const bodyId = useId();
+  return (
+    <Stack gap="xs">
+      <UnstyledButton
+        className="collapsible-section-trigger"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={bodyId}
+      >
+        <Group gap="xs" wrap="nowrap">
+          <ChevronIcon open={open} />
+          <Text style={SECTION_TITLE_STYLE}>{title}</Text>
+        </Group>
+      </UnstyledButton>
+      <Collapse in={open} id={bodyId}>
+        {children}
+      </Collapse>
+    </Stack>
+  );
+}

--- a/app/status_monitor/frontend/src/components/DetectorDetails.jsx
+++ b/app/status_monitor/frontend/src/components/DetectorDetails.jsx
@@ -100,6 +100,7 @@ function PipelineCell({ yaml }) {
     <div>
       <div style={{ position: "relative" }}>
         <div
+          className="theme-code"
           style={{
             maxHeight: expanded || !needsCollapse ? "none" : YAML_COLLAPSED_HEIGHT,
             overflow: "hidden",

--- a/app/status_monitor/frontend/src/components/DetectorDetails.jsx
+++ b/app/status_monitor/frontend/src/components/DetectorDetails.jsx
@@ -100,7 +100,6 @@ function PipelineCell({ yaml }) {
     <div>
       <div style={{ position: "relative" }}>
         <div
-          className="theme-code"
           style={{
             maxHeight: expanded || !needsCollapse ? "none" : YAML_COLLAPSED_HEIGHT,
             overflow: "hidden",

--- a/app/status_monitor/frontend/src/components/DetectorDetails.jsx
+++ b/app/status_monitor/frontend/src/components/DetectorDetails.jsx
@@ -12,10 +12,10 @@ import {
   Group,
 } from "@mantine/core";
 import { CodeHighlight } from "@mantine/code-highlight";
+import { DARK_HEADER_STYLE } from "../sharedStyles";
 
 const TH_STYLE = {
-  backgroundColor: "#3a383c",
-  color: "#fff",
+  ...DARK_HEADER_STYLE,
   whiteSpace: "nowrap",
 };
 

--- a/app/status_monitor/frontend/src/main.jsx
+++ b/app/status_monitor/frontend/src/main.jsx
@@ -11,9 +11,9 @@ import yaml from "highlight.js/lib/languages/yaml";
 import plaintext from "highlight.js/lib/languages/plaintext";
 import "@mantine/core/styles.css";
 import "@mantine/code-highlight/styles.css";
-import "highlight.js/styles/github.css";
 import App from "./App";
 import "./App.css";
+import "./code-themes.css";
 
 hljs.registerLanguage("json", json);
 hljs.registerLanguage("yaml", yaml);

--- a/app/status_monitor/frontend/src/sharedStyles.js
+++ b/app/status_monitor/frontend/src/sharedStyles.js
@@ -6,3 +6,12 @@ export const DARK_HEADER_STYLE = {
   backgroundColor: "#3a383c",
   color: "#fff",
 };
+
+// Style for the heading above each top-level section on the status page.
+// Owned by CollapsibleSection so every section reads as the same visual
+// element.
+export const SECTION_TITLE_STYLE = {
+  fontSize: "1.25em",
+  fontWeight: 500,
+  color: "#1F1D23",
+};

--- a/app/status_monitor/frontend/src/sharedStyles.js
+++ b/app/status_monitor/frontend/src/sharedStyles.js
@@ -1,0 +1,8 @@
+// Shared inline styles used by multiple components on the status page.
+
+// Dark gray bar used by table headers and code-block headers. Keep these in
+// sync so the page reads as a single visual system.
+export const DARK_HEADER_STYLE = {
+  backgroundColor: "#3a383c",
+  color: "#fff",
+};

--- a/app/status_monitor/frontend/vite.config.js
+++ b/app/status_monitor/frontend/vite.config.js
@@ -19,6 +19,7 @@ export default defineConfig({
       "/status/resources.json": EDGE_ENDPOINT,
       "/status/static/icon_gold_dark.svg": EDGE_ENDPOINT,
       "/status/static/favicon.ico": EDGE_ENDPOINT,
+      "/edge-config": EDGE_ENDPOINT,
     },
   },
 });


### PR DESCRIPTION
The "Groundlight Edge Endpoint Status" page now shows the configuration that the Edge Endpoint is using. The user can choose between yaml or json. yaml is default. 

<img width="1089" height="786" alt="image" src="https://github.com/user-attachments/assets/1d6ca009-10ac-4c17-a8f8-bd54ffd68013" />
