### PR TITLE
Drain stacked FUSE mounts and verify mount is usable in mount-s3.sh

### DIFF
--- a/deploy/bin/mount-s3.sh
+++ b/deploy/bin/mount-s3.sh
@@ -17,12 +17,25 @@ set -e
 MOUNT_POINT="/host-root${MOUNT_PATH}"
 CACHE_DIR="/host-root${CACHE_PATH}"
 
-# Unmount any stale mount from a previous run before mkdir, since stat() on an
-# orphaned FUSE endpoint fails with ENOTCONN and would break `mkdir -p` below.
-if ! stat "$MOUNT_POINT" >/dev/null 2>&1 || mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
-    echo "Cleaning up stale mount at $MOUNT_POINT"
-    umount "$MOUNT_POINT" 2>/dev/null || fusermount -u "$MOUNT_POINT" 2>/dev/null || true
-fi
+# Drain any stale or stacked FUSE mounts left from previous runs. A single
+# umount is not enough: when a prior cleanup partially failed (e.g. the mount
+# was busy or the daemon already gone), mount-s3 will happily mount on top of
+# the existing entry, leaving a stack. Callers then traverse to the topmost
+# layer; if that one is a zombie, every access returns ENOTCONN.
+attempts=0
+max_attempts=5
+while ! stat "$MOUNT_POINT" >/dev/null 2>&1 \
+   || mountpoint -q "$MOUNT_POINT" 2>/dev/null; do
+    if [ "$attempts" -ge "$max_attempts" ]; then
+        echo "WARNING: gave up draining mounts at $MOUNT_POINT after $attempts attempts" >&2
+        break
+    fi
+    echo "Cleaning up stale mount at $MOUNT_POINT (attempt $((attempts + 1)))"
+    umount -l "$MOUNT_POINT" 2>/dev/null \
+        || fusermount -uz "$MOUNT_POINT" 2>/dev/null \
+        || break
+    attempts=$((attempts + 1))
+done
 
 mkdir -p "$MOUNT_POINT" "$CACHE_DIR"
 

--- a/deploy/bin/mount-s3.sh
+++ b/deploy/bin/mount-s3.sh
@@ -54,7 +54,12 @@ MOUNT_PID=$!
 # completes its initial mount within a few seconds.
 verified=0
 for _ in $(seq 1 30); do
-    if mountpoint -q "$MOUNT_POINT" 2>/dev/null \
+    # Require the mount-s3 process we just spawned to still be alive: during a
+    # rolling deploy, the previous pod's mount can still be propagated to the
+    # host and pass the mountpoint+ls check even though our new mount-s3 has
+    # already failed (e.g. "mountpoint is not empty").
+    if kill -0 "$MOUNT_PID" 2>/dev/null \
+       && mountpoint -q "$MOUNT_POINT" 2>/dev/null \
        && [ -n "$(ls -A "$MOUNT_POINT" 2>/dev/null)" ]; then
         verified=1
         break

--- a/deploy/bin/mount-s3.sh
+++ b/deploy/bin/mount-s3.sh
@@ -52,6 +52,12 @@ MOUNT_PID=$!
 # mount-s3 starting against the wrong bucket (empty listing) or a FUSE mount
 # that established but isn't actually serving content. mount-s3 normally
 # completes its initial mount within a few seconds.
+#
+# Note: this assumes the configured bucket is non-empty. A legitimately empty
+# bucket would fail verification and the container would crash-loop with a
+# misleading "mount verification failed" error. pinamod-artifacts-public is
+# always populated in practice, so this tradeoff catches misconfigurations
+# (typo'd bucket name, wrong region) at the cost of a hypothetical edge case.
 verified=0
 for _ in $(seq 1 30); do
     # Require the mount-s3 process we just spawned to still be alive: during a

--- a/deploy/bin/mount-s3.sh
+++ b/deploy/bin/mount-s3.sh
@@ -45,4 +45,29 @@ mount-s3 "$S3_BUCKET" "$MOUNT_POINT" \
     --read-only \
     --cache "$CACHE_DIR" \
     --allow-other \
-    --foreground
+    --foreground &
+MOUNT_PID=$!
+
+# Verify the mount comes up healthy within 30s. Catches subtle failures like
+# mount-s3 starting against the wrong bucket (empty listing) or a FUSE mount
+# that established but isn't actually serving content. mount-s3 normally
+# completes its initial mount within a few seconds.
+verified=0
+for _ in $(seq 1 30); do
+    if mountpoint -q "$MOUNT_POINT" 2>/dev/null \
+       && [ -n "$(ls -A "$MOUNT_POINT" 2>/dev/null)" ]; then
+        verified=1
+        break
+    fi
+    sleep 1
+done
+
+if [ "$verified" -ne 1 ]; then
+    echo "ERROR: mount verification failed for $MOUNT_POINT (mount-s3 PID $MOUNT_PID)" >&2
+    kill -TERM "$MOUNT_PID" 2>/dev/null || true
+    wait "$MOUNT_PID" 2>/dev/null || true
+    exit 1
+fi
+
+echo "Mount verified at $MOUNT_POINT"
+wait "$MOUNT_PID"


### PR DESCRIPTION
## Summary

Follow-up hardening to #387 for the mount-s3 sidecar. Three changes:

1. **Drain stacked FUSE mounts.** Replace the one-shot `umount` with a bounded loop that uses `umount -l` + `fusermount -uz`, so a stack of stale layers actually clears instead of `mount-s3` adding a new layer on top.
2. **Verify the mount is usable.** Run `mount-s3` in the background, poll the path for `mountpoint -q` + non-empty `ls -A` for up to 30s, exit non-zero with a clear error if it doesn't come up healthy.
3. **Gate verification on the spawned process being alive.** During a rolling deploy, the previous pod's mount can still be propagated to the host and falsely satisfy the mountpoint+ls check. `kill -0 $MOUNT_PID` makes verification only succeed when our own `mount-s3` is the one backing the mount.

## Why this matters

Observed on a balena device (`6c2220e…`) running the post-#387 code:

```
$ mount | grep pinamod-mount
mountpoint-s3 on /opt/groundlight/edge/pinamod-mount type fuse (...)
mountpoint-s3 on /opt/groundlight/edge/pinamod-mount type fuse (...)
$ stat /opt/groundlight/edge/pinamod-mount
stat: cannot statx '...': Transport endpoint is not connected
```

Two FUSE mounts were stacked at the same path. Only one `mount-s3` daemon was alive (PID 4222 backing one of them), so the topmost layer was a zombie and every access from inference pods returned `ENOTCONN`. The pod itself was healthy with 0 restarts — it inherited the stack from a prior pod.

Manually draining the stack (`umount -l` twice, then deleting the pod) restored a single healthy mount and unblocked the device.

## How stacking happens

| Step | State at `/opt/groundlight/edge/pinamod-mount` |
| --- | --- |
| Pod A starts, mounts | `[A]` |
| `mount-s3` daemon A dies (OOM / crash / network blip) — kernel keeps the mount entry as a zombie | `[A-zombie]` |
| Pod A's sidecar restarts, `umount` fails silently (busy / already-gone), `mount-s3` runs again | `[A-zombie, B]` |
| Daemon B later dies | `[A-zombie, B-zombie]` |
| Sidecar restart cleans up *one* layer, then mounts fresh | `[A-zombie, C]` |

The current `umount "$MOUNT_POINT" || fusermount -u "$MOUNT_POINT" || true` removes at most one layer per sidecar invocation. With non-lazy flags it also gives up immediately on `EBUSY`, which a hostPath consumer (like an inference pod's `/opt/models`) can easily produce.

## Changes

- `deploy/bin/mount-s3.sh`:
  - Replace the one-shot `if ... then umount ... fi` cleanup with a bounded `while` loop (max 5 iterations). `umount -l` (lazy) with a `fusermount -uz` fallback, both of which can release disconnected/busy mounts that plain `umount` cannot. Loop exits cleanly when the path is no longer a mountpoint, or breaks (with a warning) if both unmount commands fail.
  - Run `mount-s3` in the background; poll `mountpoint -q $MOUNT_POINT && [ -n "$(ls -A $MOUNT_POINT)" ] && kill -0 $MOUNT_PID` for up to 30s. On success, log `Mount verified at ...` and `wait` on the daemon. On failure, kill `mount-s3` and `exit 1` with a clear error so the kubelet restarts the container.
- No change to the cache directory handling, the `mkdir -p`, or the chart templates.

## Why >5 stacked mounts is still safe

The cap is a runaway-loop brake, not a hard ceiling. If 6+ layers are stacked, the loop drains 5 then breaks. If the layer remaining at the top is healthy, `mkdir -p` succeeds and `mount-s3` mounts fresh on top — the next sidecar restart drains another 5. If the top layer is dead, `mkdir -p` hits ENOTCONN, `set -e` exits the script, the container restarts, and the next loop drains another 5. Either way the script self-heals across restarts.

## Cache safety

The fix only touches mount table entries via `umount`/`fusermount`/`kill`. The cache lives at a separate path (`/opt/groundlight/edge/pinamod-cache`) on persistent host disk and is not modified. Helm upgrades preserve cache content as before.

## Test plan

All three test cases run on g4 against the `:dev` image built from this branch.

- [x] **Clean rollout produces exactly one mount.** Helm install with `edgeEndpointTag=dev`, sidecar logs end with `successfully mounted bucket pinamod-artifacts-public ...` followed by `Mount verified at /host-root/opt/groundlight/edge/pinamod-mount`. `mount | grep -c pinamod-mount` → `1`.
- [x] **Self-heal after the mount-s3 daemon is killed.** `sudo kill -9 <mount-s3 pid>` on the host. Sidecar restarts; new container's logs show `Cleaning up stale mount at ... (attempt 1)` then `successfully mounted ...` then `Mount verified at ...`. Final mount count: `1`. `stat` and `ls` both work.
- [x] **Rolling deploy doesn't false-positive verification.** During a `kubectl rollout restart`, the new pod's first sidecar attempt initially saw the previous pod's still-propagated mount (`fuse: mountpoint is not empty` from the new mount-s3); verification did NOT print `Mount verified` because `kill -0 $MOUNT_PID` failed once mount-s3 exited. `set -e` via `wait` exited the script, the container restarted once, second attempt succeeded cleanly.
- [x] **Failure case fires verification.** `kubectl set env -c mount-s3 S3_BUCKET=nonexistent-bucket-xyz-test-fail`. mount-s3 exits with `The bucket does not exist`; verification times out and logs:
  ```
  ERROR: mount verification failed for /host-root/opt/groundlight/edge/pinamod-mount (mount-s3 PID 10)
  ```
  Container CrashLoops with the error visible in `kubectl logs ... -p`.
- [x] **Recovery after restoring correct env.** Setting `S3_BUCKET` back to `pinamod-artifacts-public` produces a fresh pod, 6/6 Running, 0 restarts, exactly 1 mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)