### PR TITLE
Add CPU and GPU utilization to  `/status/resources.json` 

### DIFF
--- a/app/metrics/resource_metrics.py
+++ b/app/metrics/resource_metrics.py
@@ -120,12 +120,12 @@ class ResourceMetricsCollector:
         pod_list = v1.list_namespaced_pod(namespace=namespace)
         inference_pods = _find_inference_pods(pod_list)
         node_resources = _get_node_resources(v1)
-        ram_by_pod = _get_pod_ram_metrics(namespace)
+        pod_resources = _get_pod_resource_metrics(namespace)
 
         if inference_pods:
             active_pods = _pick_active_pods(inference_pods)
             gpu_responses = _query_all_pod_gpus(inference_pods)
-            observed_gpus, gpu_devices, total_vram, used_vram, gpu_compute_pct, gpu_memory_bw_pct = _build_gpu_summary(
+            _, gpu_devices, total_vram, used_vram, gpu_compute_pct, gpu_memory_bw_pct = _build_gpu_summary(
                 gpu_responses
             )
             (
@@ -134,17 +134,20 @@ class ResourceMetricsCollector:
                 loading_ram,
                 loading_gpu_compute_pct,
                 loading_gpu_memory_bw_pct,
+                loading_cpu_millicores,
             ) = _attribute_detector_resources(
                 inference_pods,
                 active_pods,
                 gpu_responses,
-                ram_by_pod,
+                pod_resources,
+                node_resources["cpu"]["total_millicores"],
             )
         else:
-            observed_gpus, gpu_devices, total_vram, used_vram = [], [], 0, 0
+            gpu_devices, total_vram, used_vram = [], 0, 0
             gpu_compute_pct, gpu_memory_bw_pct = 0.0, 0.0
             detectors, loading_vram, loading_ram = [], 0, 0
             loading_gpu_compute_pct, loading_gpu_memory_bw_pct = 0.0, 0.0
+            loading_cpu_millicores = 0.0
 
         # Anything in the namespace that isn't a recognised Running inference
         # pod counts as "edge-endpoint platform overhead": the edge-endpoint
@@ -154,31 +157,60 @@ class ResourceMetricsCollector:
         # since the namespace is chart-owned and unlikely to host foreign pods.
         inference_pod_names = {pod.metadata.name for pod, _, _, _ in inference_pods}
         edge_endpoint_ram = sum(
-            bytes_used for name, bytes_used in ram_by_pod.items() if name not in inference_pod_names
+            resource["ram_bytes"] for name, resource in pod_resources.items() if name not in inference_pod_names
+        )
+        edge_endpoint_cpu_millicores = sum(
+            resource["cpu_millicores"] for name, resource in pod_resources.items() if name not in inference_pod_names
+        )
+        detector_ram = sum(det["ram_bytes"]["total"] for det in detectors)
+        detector_vram = sum(det["gpu"]["vram_bytes"]["total"] for det in detectors)
+        detector_cpu_pct = sum(det["cpu_utilization_pct"]["total"] for det in detectors)
+        detector_gpu_compute_pct = sum(det["gpu"]["compute_utilization_pct"]["total"] for det in detectors)
+        detector_gpu_memory_bw_pct = sum(det["gpu"]["memory_bandwidth_pct"]["total"] for det in detectors)
+        edge_endpoint_cpu_pct = _percentage(edge_endpoint_cpu_millicores, node_resources["cpu"]["total_millicores"])
+        loading_cpu_pct = _percentage(loading_cpu_millicores, node_resources["cpu"]["total_millicores"])
+        other_cpu_pct = max(
+            0.0,
+            node_resources["cpu"]["utilization_pct"] - detector_cpu_pct - loading_cpu_pct - edge_endpoint_cpu_pct,
         )
 
         return {
             "system": {
-                "cpu": node_resources["cpu"],
-                "ram": {
-                    "used_bytes": node_resources["ram"]["used"],
-                    "total_bytes": node_resources["ram"]["total"],
-                    "loading_detectors_bytes": loading_ram,
-                    "edge_endpoint_bytes": edge_endpoint_ram,
+                "cpu_utilization_pct": {
+                    "total": node_resources["cpu"]["utilization_pct"],
+                    "detectors": detector_cpu_pct,
+                    "loading_detectors": loading_cpu_pct,
+                    "edge_endpoint": edge_endpoint_cpu_pct,
+                    "other": other_cpu_pct,
+                },
+                "ram_bytes": {
+                    "total": node_resources["ram"]["total"],
+                    "used": node_resources["ram"]["used"],
+                    "detectors": detector_ram,
+                    "loading_detectors": loading_ram,
+                    "edge_endpoint": edge_endpoint_ram,
+                    "other": max(0, node_resources["ram"]["used"] - detector_ram - loading_ram - edge_endpoint_ram),
                     "eviction_threshold_pct": node_resources["ram"]["eviction_threshold_pct"],
                 },
-                "vram": {
-                    "used_bytes": used_vram,
-                    "total_bytes": total_vram,
-                    "loading_detectors_bytes": loading_vram,
-                    "edge_endpoint_bytes": 0,  # Only inference pods consume VRAM
-                    "observed_gpus": observed_gpus,
-                },
                 "gpu": {
-                    "compute_utilization_pct": gpu_compute_pct,
-                    "memory_bandwidth_pct": gpu_memory_bw_pct,
-                    "loading_detectors_compute_utilization_pct": loading_gpu_compute_pct,
-                    "loading_detectors_memory_bandwidth_pct": loading_gpu_memory_bw_pct,
+                    "vram_bytes": {
+                        "total": total_vram,
+                        "used": used_vram,
+                        "detectors": detector_vram,
+                        "loading_detectors": loading_vram,
+                        "edge_endpoint": 0,
+                        "other": max(0, used_vram - detector_vram - loading_vram),
+                    },
+                    "compute_utilization_pct": {
+                        "total": gpu_compute_pct,
+                        "detectors": detector_gpu_compute_pct,
+                        "loading_detectors": loading_gpu_compute_pct,
+                    },
+                    "memory_bandwidth_pct": {
+                        "total": gpu_memory_bw_pct,
+                        "detectors": detector_gpu_memory_bw_pct,
+                        "loading_detectors": loading_gpu_memory_bw_pct,
+                    },
                     "devices": gpu_devices,
                 },
             },
@@ -224,13 +256,17 @@ def _get_node_resources(v1: "client.CoreV1Api") -> dict:
 
         return {
             "ram": {"total": total_ram, "used": used_ram, "eviction_threshold_pct": eviction_pct},
-            "cpu": {"utilization_pct": cpu_utilization_pct},
+            "cpu": {
+                "utilization_pct": cpu_utilization_pct,
+                "used_millicores": used_cpu_millicores,
+                "total_millicores": total_cpu_millicores,
+            },
         }
     except Exception:
         logger.error("Failed to get node resources from Kubernetes APIs", exc_info=True)
         return {
             "ram": {"total": 0, "used": 0, "eviction_threshold_pct": None},
-            "cpu": {"utilization_pct": 0.0},
+            "cpu": {"utilization_pct": 0.0, "used_millicores": 0.0, "total_millicores": 0.0},
         }
 
 
@@ -342,7 +378,7 @@ def _query_all_pod_gpus(inference_pods: list[tuple]) -> dict[str, dict | None]:
 def _build_gpu_summary(gpu_responses: dict[str, dict | None]) -> tuple[list, list, int, int, float, float]:
     """Aggregate GPU device observations across all queried pods.
 
-    Returns compatibility VRAM device entries, v2-style GPU device entries,
+    Returns compatibility VRAM device entries, nested GPU device entries,
     aggregate VRAM bytes, and average device-wide GPU utilization.
     """
     devices_by_key: dict[str, dict] = {}
@@ -375,16 +411,19 @@ def _build_gpu_summary(gpu_responses: dict[str, dict | None]) -> tuple[list, lis
                     "index": gpu_index,
                     "uuid": gpu_uuid,
                     "name": gpu_name,
-                    "vram_total_bytes": gpu_total,
-                    "vram_used_bytes": gpu_used,
-                    "vram_free_bytes": gpu_free,
+                    "vram_bytes": {
+                        "total": gpu_total,
+                        "used": gpu_used,
+                        "free": gpu_free,
+                    },
                     "compute_utilization_pct": compute_pct,
                     "memory_bandwidth_pct": memory_bw_pct,
                 }
             else:
-                existing["vram_total_bytes"] = max(existing.get("vram_total_bytes", 0), gpu_total)
-                existing["vram_used_bytes"] = max(existing.get("vram_used_bytes", 0), gpu_used)
-                existing["vram_free_bytes"] = max(existing.get("vram_free_bytes", 0), gpu_free)
+                existing_vram = existing["vram_bytes"]
+                existing_vram["total"] = max(existing_vram.get("total", 0), gpu_total)
+                existing_vram["used"] = max(existing_vram.get("used", 0), gpu_used)
+                existing_vram["free"] = max(existing_vram.get("free", 0), gpu_free)
                 existing["compute_utilization_pct"] = max(existing.get("compute_utilization_pct", 0.0), compute_pct)
                 existing["memory_bandwidth_pct"] = max(existing.get("memory_bandwidth_pct", 0.0), memory_bw_pct)
 
@@ -407,8 +446,8 @@ def _build_gpu_summary(gpu_responses: dict[str, dict | None]) -> tuple[list, lis
         {
             "name": device["name"],
             "index": device["index"],
-            "used_bytes": device["vram_used_bytes"],
-            "total_bytes": device["vram_total_bytes"],
+            "used_bytes": device["vram_bytes"]["used"],
+            "total_bytes": device["vram_bytes"]["total"],
         }
         for device in sorted_devices
     ]
@@ -425,8 +464,9 @@ def _attribute_detector_resources(
     inference_pods: list[tuple],
     active_pods: set[str],
     gpu_responses: dict[str, dict | None],
-    ram_by_pod: dict[str, int],
-) -> tuple[list, int, int, float, float]:
+    pod_resources: dict[str, dict[str, float]],
+    total_cpu_millicores: float,
+) -> tuple[list, int, int, float, float, float]:
     """Attribute VRAM, GPU utilization, and RAM to individual detectors or loading totals.
 
     Returns detector entries, loading VRAM/RAM, and loading GPU utilization
@@ -438,18 +478,16 @@ def _attribute_detector_resources(
     loading_ram_bytes = 0
     loading_gpu_compute_pct = 0.0
     loading_gpu_memory_bw_pct = 0.0
+    loading_cpu_millicores = 0.0
 
     def _blank_resource() -> dict:
-        return {"primary_bytes": None, "oodd_bytes": None, "total_bytes": 0}
+        return {"primary": None, "oodd": None, "total": 0}
 
     def _blank_gpu() -> dict:
         return {
-            "primary_compute_utilization_pct": None,
-            "oodd_compute_utilization_pct": None,
-            "total_compute_utilization_pct": 0.0,
-            "primary_memory_bandwidth_pct": None,
-            "oodd_memory_bandwidth_pct": None,
-            "total_memory_bandwidth_pct": 0.0,
+            "vram_bytes": _blank_resource(),
+            "compute_utilization_pct": _blank_resource(),
+            "memory_bandwidth_pct": _blank_resource(),
         }
 
     for pod, det_id, is_oodd, _is_ready in inference_pods:
@@ -458,11 +496,15 @@ def _attribute_detector_resources(
         process_vram = process_info.get("vram_used_bytes") or 0
         process_compute_pct = float(process_info.get("compute_utilization_pct") or 0.0)
         process_memory_bw_pct = float(process_info.get("memory_bandwidth_pct") or 0.0)
-        process_ram = ram_by_pod.get(pod.metadata.name, 0)
+        pod_resource = pod_resources.get(pod.metadata.name, {})
+        process_ram = int(pod_resource.get("ram_bytes", 0))
+        process_cpu_millicores = float(pod_resource.get("cpu_millicores", 0.0))
+        process_cpu_pct = _percentage(process_cpu_millicores, total_cpu_millicores)
 
         if pod.metadata.name not in active_pods:
             loading_vram_bytes += process_vram
             loading_ram_bytes += process_ram
+            loading_cpu_millicores += process_cpu_millicores
             loading_gpu_compute_pct = min(loading_gpu_compute_pct + process_compute_pct, 100.0)
             loading_gpu_memory_bw_pct = min(loading_gpu_memory_bw_pct + process_memory_bw_pct, 100.0)
             continue
@@ -470,28 +512,38 @@ def _attribute_detector_resources(
         if det_id not in detectors:
             detectors[det_id] = {
                 "detector_id": det_id,
-                "ram": _blank_resource(),
-                "vram": _blank_resource(),
+                "cpu_utilization_pct": _blank_resource(),
+                "ram_bytes": _blank_resource(),
                 "gpu": _blank_gpu(),
             }
         det = detectors[det_id]
-        bytes_slot = "oodd_bytes" if is_oodd else "primary_bytes"
-        compute_slot = "oodd_compute_utilization_pct" if is_oodd else "primary_compute_utilization_pct"
-        memory_slot = "oodd_memory_bandwidth_pct" if is_oodd else "primary_memory_bandwidth_pct"
-        det["vram"][bytes_slot] = (det["vram"][bytes_slot] or 0) + process_vram
-        det["ram"][bytes_slot] = (det["ram"][bytes_slot] or 0) + process_ram
-        det["gpu"][compute_slot] = min((det["gpu"][compute_slot] or 0.0) + process_compute_pct, 100.0)
-        det["gpu"][memory_slot] = min((det["gpu"][memory_slot] or 0.0) + process_memory_bw_pct, 100.0)
-        det["vram"]["total_bytes"] = (det["vram"]["primary_bytes"] or 0) + (det["vram"]["oodd_bytes"] or 0)
-        det["ram"]["total_bytes"] = (det["ram"]["primary_bytes"] or 0) + (det["ram"]["oodd_bytes"] or 0)
-        det["gpu"]["total_compute_utilization_pct"] = min(
-            (det["gpu"]["primary_compute_utilization_pct"] or 0.0)
-            + (det["gpu"]["oodd_compute_utilization_pct"] or 0.0),
+        slot = "oodd" if is_oodd else "primary"
+        det["cpu_utilization_pct"][slot] = (det["cpu_utilization_pct"][slot] or 0.0) + process_cpu_pct
+        det["ram_bytes"][slot] = (det["ram_bytes"][slot] or 0) + process_ram
+        det["gpu"]["vram_bytes"][slot] = (det["gpu"]["vram_bytes"][slot] or 0) + process_vram
+        det["gpu"]["compute_utilization_pct"][slot] = min(
+            (det["gpu"]["compute_utilization_pct"][slot] or 0.0) + process_compute_pct,
             100.0,
         )
-        det["gpu"]["total_memory_bandwidth_pct"] = min(
-            (det["gpu"]["primary_memory_bandwidth_pct"] or 0.0)
-            + (det["gpu"]["oodd_memory_bandwidth_pct"] or 0.0),
+        det["gpu"]["memory_bandwidth_pct"][slot] = min(
+            (det["gpu"]["memory_bandwidth_pct"][slot] or 0.0) + process_memory_bw_pct,
+            100.0,
+        )
+        det["cpu_utilization_pct"]["total"] = (det["cpu_utilization_pct"]["primary"] or 0.0) + (
+            det["cpu_utilization_pct"]["oodd"] or 0.0
+        )
+        det["ram_bytes"]["total"] = (det["ram_bytes"]["primary"] or 0) + (det["ram_bytes"]["oodd"] or 0)
+        det["gpu"]["vram_bytes"]["total"] = (det["gpu"]["vram_bytes"]["primary"] or 0) + (
+            det["gpu"]["vram_bytes"]["oodd"] or 0
+        )
+        det["gpu"]["compute_utilization_pct"]["total"] = min(
+            (det["gpu"]["compute_utilization_pct"]["primary"] or 0.0)
+            + (det["gpu"]["compute_utilization_pct"]["oodd"] or 0.0),
+            100.0,
+        )
+        det["gpu"]["memory_bandwidth_pct"]["total"] = min(
+            (det["gpu"]["memory_bandwidth_pct"]["primary"] or 0.0)
+            + (det["gpu"]["memory_bandwidth_pct"]["oodd"] or 0.0),
             100.0,
         )
 
@@ -501,14 +553,15 @@ def _attribute_detector_resources(
         loading_ram_bytes,
         loading_gpu_compute_pct,
         loading_gpu_memory_bw_pct,
+        loading_cpu_millicores,
     )
 
 
-def _get_pod_ram_metrics(namespace: str) -> dict[str, int]:
-    """Query the Kubernetes Metrics Server for per-pod RAM usage.
+def _get_pod_resource_metrics(namespace: str) -> dict[str, dict[str, float]]:
+    """Query the Kubernetes Metrics Server for per-pod RAM and CPU usage.
 
-    Returns {pod_name: total_ram_bytes}. Returns an empty dict if the
-    Metrics Server is unavailable.
+    Returns {pod_name: {"ram_bytes": ..., "cpu_millicores": ...}}. Returns an
+    empty dict if the Metrics Server is unavailable.
     """
     try:
         custom = client.CustomObjectsApi()
@@ -519,15 +572,17 @@ def _get_pod_ram_metrics(namespace: str) -> dict[str, int]:
             plural="pods",
         )
     except Exception:
-        logger.debug("Metrics Server unavailable, skipping RAM metrics")
+        logger.debug("Metrics Server unavailable, skipping pod resource metrics")
         return {}
 
-    ram_by_pod: dict[str, int] = {}
+    resources_by_pod: dict[str, dict[str, float]] = {}
     for item in result.get("items", []):
         pod_name = item.get("metadata", {}).get("name", "")
-        total = 0
+        ram_total = 0
+        cpu_total = 0.0
         for container in item.get("containers", []):
             usage = container.get("usage", {})
-            total += _parse_k8s_memory(usage.get("memory", "0"))
-        ram_by_pod[pod_name] = total
-    return ram_by_pod
+            ram_total += _parse_k8s_memory(usage.get("memory", "0"))
+            cpu_total += _parse_k8s_cpu(usage.get("cpu", "0"))
+        resources_by_pod[pod_name] = {"ram_bytes": ram_total, "cpu_millicores": cpu_total}
+    return resources_by_pod

--- a/app/metrics/resource_metrics.py
+++ b/app/metrics/resource_metrics.py
@@ -1,8 +1,8 @@
-"""Collects per-detector GPU and RAM usage for the status page.
+"""Collects per-detector GPU, VRAM, RAM, and CPU usage for the status page.
 
-GPU (VRAM) data comes from each inference pod's /gpu-usage HTTP endpoint.
+GPU and VRAM data comes from each inference pod's /v2/gpu-usage HTTP endpoint.
 RAM data comes from the Kubernetes Metrics Server (metrics.k8s.io/v1beta1).
-System-level RAM uses the Kubernetes Node API so that the numbers match
+System-level RAM and CPU use the Kubernetes Node API so that the numbers match
 the kubelet's view of memory (which drives eviction decisions).
 
 RAM used by non-inference pods in the edge namespace (the edge-endpoint
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal, InvalidOperation
 
 import requests
 from kubernetes import client, config
@@ -24,7 +25,7 @@ from app.metrics.system_metrics import _DATETIME_MIN_UTC, _pod_is_ready, get_nam
 logger = logging.getLogger(__name__)
 
 GPU_ENDPOINT_PORT = 8000
-GPU_ENDPOINT_PATH = "/gpu-usage"
+GPU_ENDPOINT_PATH = "/v2/gpu-usage"
 HTTP_TIMEOUT_SEC = 2
 GPU_QUERY_MAX_WORKERS = 16
 
@@ -39,6 +40,12 @@ _K8S_MEM_SUFFIXES = {
     "T": 1000**4,
 }
 _K8S_MEM_RE = re.compile(r"^(\d+(?:\.\d+)?)([A-Za-z]{1,2})?$")
+_K8S_CPU_SUFFIX_TO_MILLICORES = {
+    "n": Decimal("0.000001"),
+    "u": Decimal("0.001"),
+    "m": Decimal("1"),
+}
+_K8S_CPU_RE = re.compile(r"^(\d+(?:\.\d+)?)([num])?$")
 
 
 def _parse_k8s_memory(quantity: str) -> int:
@@ -58,25 +65,47 @@ def _parse_k8s_memory(quantity: str) -> int:
     return int(value * multiplier)
 
 
-class ResourceMetricsCollector:
-    """Collects GPU and RAM usage per inference pod.
+def _parse_k8s_cpu(quantity: str) -> float:
+    """Parse a Kubernetes CPU quantity string into millicores."""
+    m = _K8S_CPU_RE.match(quantity)
+    if not m:
+        logger.warning("Could not parse Kubernetes CPU quantity %r; returning 0", quantity)
+        return 0.0
+    try:
+        value = Decimal(m.group(1))
+    except InvalidOperation:
+        logger.warning("Could not parse Kubernetes CPU quantity %r; returning 0", quantity)
+        return 0.0
 
-    The emitted payload is grouped by resource type (`ram` / `vram`) at both the
-    system level and per-detector, so every resource has a consistent shape
-    (`used_bytes`, `total_bytes`, ...) and new resources can be added without
-    reshuffling top-level keys.
+    suffix = m.group(2)
+    multiplier = _K8S_CPU_SUFFIX_TO_MILLICORES.get(suffix, Decimal("1000")) if suffix else Decimal("1000")
+    return float(value * multiplier)
+
+
+def _percentage(numerator: float, denominator: float) -> float:
+    """Return a percentage, or 0.0 when the denominator is zero."""
+    if denominator <= 0:
+        return 0.0
+    return numerator / denominator * 100
+
+
+class ResourceMetricsCollector:
+    """Collects GPU, VRAM, RAM, and CPU usage for status reporting.
+
+    The emitted payload is grouped by resource type at the system level and
+    per-detector so existing RAM/VRAM consumers remain stable while newer GPU
+    and CPU utilization metrics can be added.
     """
 
     def collect(self) -> dict:
         """Build the `/status/resources.json` payload.
 
         Returns a dict with two top-level keys:
-            - `system`: node-wide `ram` and `vram` totals, plus aggregate
-              buckets for currently-loading detectors, edge-endpoint platform
-              overhead, and (for VRAM) the list of observed GPU devices.
+            - `system`: node-wide `cpu`, `ram`, `vram`, and `gpu` totals, plus
+              aggregate buckets for currently-loading detectors, edge-endpoint
+              platform overhead, and the list of observed GPU devices.
             - `detectors`: a list of per-detector entries, each with nested
-              `ram` and `vram` objects containing `primary_bytes`,
-              `oodd_bytes`, and `total_bytes`.
+              `ram`, `vram`, and `gpu` objects.
 
         If called outside a Kubernetes cluster, returns `{"error": "..."}`.
         """
@@ -90,19 +119,32 @@ class ResourceMetricsCollector:
         v1 = client.CoreV1Api()
         pod_list = v1.list_namespaced_pod(namespace=namespace)
         inference_pods = _find_inference_pods(pod_list)
-        node_ram = _get_node_ram(v1)
+        node_resources = _get_node_resources(v1)
         ram_by_pod = _get_pod_ram_metrics(namespace)
 
         if inference_pods:
             active_pods = _pick_active_pods(inference_pods)
             gpu_responses = _query_all_pod_gpus(inference_pods)
-            observed_gpus, total_vram, used_vram = _build_gpu_summary(gpu_responses)
-            detectors, loading_vram, loading_ram = _attribute_detector_resources(
-                inference_pods, active_pods, gpu_responses, ram_by_pod
+            observed_gpus, gpu_devices, total_vram, used_vram, gpu_compute_pct, gpu_memory_bw_pct = _build_gpu_summary(
+                gpu_responses
+            )
+            (
+                detectors,
+                loading_vram,
+                loading_ram,
+                loading_gpu_compute_pct,
+                loading_gpu_memory_bw_pct,
+            ) = _attribute_detector_resources(
+                inference_pods,
+                active_pods,
+                gpu_responses,
+                ram_by_pod,
             )
         else:
-            observed_gpus, total_vram, used_vram = [], 0, 0
+            observed_gpus, gpu_devices, total_vram, used_vram = [], [], 0, 0
+            gpu_compute_pct, gpu_memory_bw_pct = 0.0, 0.0
             detectors, loading_vram, loading_ram = [], 0, 0
+            loading_gpu_compute_pct, loading_gpu_memory_bw_pct = 0.0, 0.0
 
         # Anything in the namespace that isn't a recognised Running inference
         # pod counts as "edge-endpoint platform overhead": the edge-endpoint
@@ -117,12 +159,13 @@ class ResourceMetricsCollector:
 
         return {
             "system": {
+                "cpu": node_resources["cpu"],
                 "ram": {
-                    "used_bytes": node_ram["used"],
-                    "total_bytes": node_ram["total"],
+                    "used_bytes": node_resources["ram"]["used"],
+                    "total_bytes": node_resources["ram"]["total"],
                     "loading_detectors_bytes": loading_ram,
                     "edge_endpoint_bytes": edge_endpoint_ram,
-                    "eviction_threshold_pct": node_ram["eviction_threshold_pct"],
+                    "eviction_threshold_pct": node_resources["ram"]["eviction_threshold_pct"],
                 },
                 "vram": {
                     "used_bytes": used_vram,
@@ -131,17 +174,24 @@ class ResourceMetricsCollector:
                     "edge_endpoint_bytes": 0,  # Only inference pods consume VRAM
                     "observed_gpus": observed_gpus,
                 },
+                "gpu": {
+                    "compute_utilization_pct": gpu_compute_pct,
+                    "memory_bandwidth_pct": gpu_memory_bw_pct,
+                    "loading_detectors_compute_utilization_pct": loading_gpu_compute_pct,
+                    "loading_detectors_memory_bandwidth_pct": loading_gpu_memory_bw_pct,
+                    "devices": gpu_devices,
+                },
             },
             "detectors": detectors,
         }
 
 
-def _get_node_ram(v1: "client.CoreV1Api") -> dict:
-    """Get system RAM total and used from the Kubernetes Node API and Metrics Server.
+def _get_node_resources(v1: "client.CoreV1Api") -> dict:
+    """Get node RAM details and overall CPU utilization from Kubernetes APIs.
 
-    Uses the node's capacity for total RAM and the Metrics Server for current
-    usage. This matches the kubelet's view of memory, which drives pod eviction.
-    Also extracts the kubelet's soft eviction threshold.
+    Uses node capacity for RAM and CPU totals, and Metrics Server for current
+    usage. RAM keeps the existing detailed shape, while CPU is exposed as an
+    overall utilization percentage.
     """
     try:
         node_name = os.environ.get("NODE_NAME")
@@ -151,7 +201,8 @@ def _get_node_ram(v1: "client.CoreV1Api") -> dict:
         # (spec.nodeName) so we always report capacity for the node the
         # edge-endpoint pod is actually running on, even on a multi-node cluster.
         node = v1.read_node(name=node_name)
-        total = _parse_k8s_memory(node.status.capacity.get("memory", "0"))
+        total_ram = _parse_k8s_memory(node.status.capacity.get("memory", "0"))
+        total_cpu_millicores = _parse_k8s_cpu(node.status.capacity.get("cpu", "0"))
 
         custom = client.CustomObjectsApi()
         node_metrics = custom.list_cluster_custom_object(
@@ -159,18 +210,28 @@ def _get_node_ram(v1: "client.CoreV1Api") -> dict:
             version="v1beta1",
             plural="nodes",
         )
-        used = 0
+        used_ram = 0
+        used_cpu_millicores = 0.0
         for item in node_metrics.get("items", []):
             if item.get("metadata", {}).get("name") == node.metadata.name:
-                used = _parse_k8s_memory(item.get("usage", {}).get("memory", "0"))
+                usage = item.get("usage", {})
+                used_ram = _parse_k8s_memory(usage.get("memory", "0"))
+                used_cpu_millicores = _parse_k8s_cpu(usage.get("cpu", "0"))
                 break
 
         eviction_pct = _parse_eviction_threshold(node)
+        cpu_utilization_pct = _percentage(used_cpu_millicores, total_cpu_millicores)
 
-        return {"total": total, "used": used, "eviction_threshold_pct": eviction_pct}
+        return {
+            "ram": {"total": total_ram, "used": used_ram, "eviction_threshold_pct": eviction_pct},
+            "cpu": {"utilization_pct": cpu_utilization_pct},
+        }
     except Exception:
-        logger.error("Failed to get node RAM from Kubernetes APIs", exc_info=True)
-        return {"total": 0, "used": 0, "eviction_threshold_pct": None}
+        logger.error("Failed to get node resources from Kubernetes APIs", exc_info=True)
+        return {
+            "ram": {"total": 0, "used": 0, "eviction_threshold_pct": None},
+            "cpu": {"utilization_pct": 0.0},
+        }
 
 
 _EVICTION_MEM_RE = re.compile(r"memory\.available<(\d+)%")
@@ -251,7 +312,7 @@ def _pick_active_pods(pods: list[tuple]) -> set[str]:
 
 
 def _query_pod_gpu(pod) -> dict | None:
-    """HTTP GET /gpu-usage on a single inference pod. Returns parsed JSON or None."""
+    """HTTP GET /v2/gpu-usage on a single inference pod. Returns parsed JSON or None."""
     url = f"http://{pod.status.pod_ip}:{GPU_ENDPOINT_PORT}{GPU_ENDPOINT_PATH}"
     try:
         resp = requests.get(url, timeout=HTTP_TIMEOUT_SEC)
@@ -278,44 +339,54 @@ def _query_all_pod_gpus(inference_pods: list[tuple]) -> dict[str, dict | None]:
     return {pod.metadata.name: data for pod, data in zip(pods, results)}
 
 
-def _build_gpu_summary(gpu_responses: dict[str, dict | None]) -> tuple[list, int, int]:
+def _build_gpu_summary(gpu_responses: dict[str, dict | None]) -> tuple[list, list, int, int, float, float]:
     """Aggregate GPU device observations across all queried pods.
 
-    Returns (sorted_observed_gpus, total_vram_bytes, used_vram_bytes). Each
-    entry in `sorted_observed_gpus` has keys `name`, `index`, `used_bytes`,
-    `total_bytes`.
+    Returns compatibility VRAM device entries, v2-style GPU device entries,
+    aggregate VRAM bytes, and average device-wide GPU utilization.
     """
-    observed_gpus: dict[str, dict] = {}
+    devices_by_key: dict[str, dict] = {}
     all_gpus_total = 0
     all_gpus_used = 0
 
     for gpu_data in gpu_responses.values():
         if gpu_data is None:
             continue
-        gpu_devices = gpu_data.get("gpus") or []
+        gpu_devices = gpu_data.get("devices") or []
         pod_total = 0
         pod_used = 0
         for device in gpu_devices:
             gpu_name = device.get("name")
-            gpu_total = device.get("total_bytes", 0)
-            gpu_used = device.get("used_bytes", 0)
+            gpu_total = device.get("vram_total_bytes", 0)
+            gpu_used = device.get("vram_used_bytes", 0)
+            gpu_free = device.get("vram_free_bytes", 0)
             gpu_uuid = device.get("uuid")
             gpu_index = device.get("index")
+            compute_pct = float(device.get("compute_utilization_pct") or 0.0)
+            memory_bw_pct = float(device.get("memory_bandwidth_pct") or 0.0)
             pod_total += gpu_total
             pod_used += gpu_used
             if not gpu_name:
                 continue
             key = str(gpu_uuid or f"{gpu_name}:{gpu_index}")
-            existing = observed_gpus.get(key)
-            if existing is None or gpu_total > existing.get("total_bytes", 0):
-                observed_gpus[key] = {
-                    "name": gpu_name,
+            existing = devices_by_key.get(key)
+            if existing is None:
+                devices_by_key[key] = {
                     "index": gpu_index,
-                    "used_bytes": gpu_used,
-                    "total_bytes": gpu_total,
+                    "uuid": gpu_uuid,
+                    "name": gpu_name,
+                    "vram_total_bytes": gpu_total,
+                    "vram_used_bytes": gpu_used,
+                    "vram_free_bytes": gpu_free,
+                    "compute_utilization_pct": compute_pct,
+                    "memory_bandwidth_pct": memory_bw_pct,
                 }
-            elif gpu_used > existing.get("used_bytes", 0):
-                existing["used_bytes"] = gpu_used
+            else:
+                existing["vram_total_bytes"] = max(existing.get("vram_total_bytes", 0), gpu_total)
+                existing["vram_used_bytes"] = max(existing.get("vram_used_bytes", 0), gpu_used)
+                existing["vram_free_bytes"] = max(existing.get("vram_free_bytes", 0), gpu_free)
+                existing["compute_utilization_pct"] = max(existing.get("compute_utilization_pct", 0.0), compute_pct)
+                existing["memory_bandwidth_pct"] = max(existing.get("memory_bandwidth_pct", 0.0), memory_bw_pct)
 
         # Every inference pod on a given node sees the same physical GPUs via
         # the nvidia device plugin, so we take the max across pods (dedupe)
@@ -325,14 +396,29 @@ def _build_gpu_summary(gpu_responses: dict[str, dict | None]) -> tuple[list, int
         all_gpus_total = max(all_gpus_total, pod_total)
         all_gpus_used = max(all_gpus_used, pod_used)
 
-    sorted_gpus = sorted(
-        observed_gpus.values(),
+    sorted_devices = sorted(
+        devices_by_key.values(),
         key=lambda g: (
             g.get("index") if isinstance(g.get("index"), int) else 1_000_000,
             g.get("name") or "",
         ),
     )
-    return sorted_gpus, all_gpus_total, all_gpus_used
+    observed_gpus = [
+        {
+            "name": device["name"],
+            "index": device["index"],
+            "used_bytes": device["vram_used_bytes"],
+            "total_bytes": device["vram_total_bytes"],
+        }
+        for device in sorted_devices
+    ]
+    if sorted_devices:
+        compute_pct = sum(device["compute_utilization_pct"] for device in sorted_devices) / len(sorted_devices)
+        memory_bw_pct = sum(device["memory_bandwidth_pct"] for device in sorted_devices) / len(sorted_devices)
+    else:
+        compute_pct = 0.0
+        memory_bw_pct = 0.0
+    return observed_gpus, sorted_devices, all_gpus_total, all_gpus_used, compute_pct, memory_bw_pct
 
 
 def _attribute_detector_resources(
@@ -340,30 +426,45 @@ def _attribute_detector_resources(
     active_pods: set[str],
     gpu_responses: dict[str, dict | None],
     ram_by_pod: dict[str, int],
-) -> tuple[list, int, int]:
-    """Attribute VRAM and RAM usage to individual detectors or loading totals.
+) -> tuple[list, int, int, float, float]:
+    """Attribute VRAM, GPU utilization, and RAM to individual detectors or loading totals.
 
-    Returns (detectors_list, loading_vram_bytes, loading_ram_bytes). Each
-    detector entry has the nested shape:
-        {"detector_id": ..., "ram": {...}, "vram": {...}}
-    where the inner objects have `primary_bytes`, `oodd_bytes`, `total_bytes`.
+    Returns detector entries, loading VRAM/RAM, and loading GPU utilization
+    totals. RAM/VRAM objects have primary, OODD, and total byte fields; GPU
+    objects have primary, OODD, and total utilization fields.
     """
     detectors: dict[str, dict] = {}
     loading_vram_bytes = 0
     loading_ram_bytes = 0
+    loading_gpu_compute_pct = 0.0
+    loading_gpu_memory_bw_pct = 0.0
 
     def _blank_resource() -> dict:
         return {"primary_bytes": None, "oodd_bytes": None, "total_bytes": 0}
 
+    def _blank_gpu() -> dict:
+        return {
+            "primary_compute_utilization_pct": None,
+            "oodd_compute_utilization_pct": None,
+            "total_compute_utilization_pct": 0.0,
+            "primary_memory_bandwidth_pct": None,
+            "oodd_memory_bandwidth_pct": None,
+            "total_memory_bandwidth_pct": 0.0,
+        }
+
     for pod, det_id, is_oodd, _is_ready in inference_pods:
         gpu_data = gpu_responses.get(pod.metadata.name)
-        pod_info = (gpu_data.get("pod") or {}) if gpu_data else {}
-        process_vram = pod_info.get("vram_bytes") or 0
+        process_info = (gpu_data.get("process") or {}) if gpu_data else {}
+        process_vram = process_info.get("vram_used_bytes") or 0
+        process_compute_pct = float(process_info.get("compute_utilization_pct") or 0.0)
+        process_memory_bw_pct = float(process_info.get("memory_bandwidth_pct") or 0.0)
         process_ram = ram_by_pod.get(pod.metadata.name, 0)
 
         if pod.metadata.name not in active_pods:
             loading_vram_bytes += process_vram
             loading_ram_bytes += process_ram
+            loading_gpu_compute_pct = min(loading_gpu_compute_pct + process_compute_pct, 100.0)
+            loading_gpu_memory_bw_pct = min(loading_gpu_memory_bw_pct + process_memory_bw_pct, 100.0)
             continue
 
         if det_id not in detectors:
@@ -371,15 +472,36 @@ def _attribute_detector_resources(
                 "detector_id": det_id,
                 "ram": _blank_resource(),
                 "vram": _blank_resource(),
+                "gpu": _blank_gpu(),
             }
         det = detectors[det_id]
-        slot = "oodd_bytes" if is_oodd else "primary_bytes"
-        det["vram"][slot] = (det["vram"][slot] or 0) + process_vram
-        det["ram"][slot] = (det["ram"][slot] or 0) + process_ram
+        bytes_slot = "oodd_bytes" if is_oodd else "primary_bytes"
+        compute_slot = "oodd_compute_utilization_pct" if is_oodd else "primary_compute_utilization_pct"
+        memory_slot = "oodd_memory_bandwidth_pct" if is_oodd else "primary_memory_bandwidth_pct"
+        det["vram"][bytes_slot] = (det["vram"][bytes_slot] or 0) + process_vram
+        det["ram"][bytes_slot] = (det["ram"][bytes_slot] or 0) + process_ram
+        det["gpu"][compute_slot] = min((det["gpu"][compute_slot] or 0.0) + process_compute_pct, 100.0)
+        det["gpu"][memory_slot] = min((det["gpu"][memory_slot] or 0.0) + process_memory_bw_pct, 100.0)
         det["vram"]["total_bytes"] = (det["vram"]["primary_bytes"] or 0) + (det["vram"]["oodd_bytes"] or 0)
         det["ram"]["total_bytes"] = (det["ram"]["primary_bytes"] or 0) + (det["ram"]["oodd_bytes"] or 0)
+        det["gpu"]["total_compute_utilization_pct"] = min(
+            (det["gpu"]["primary_compute_utilization_pct"] or 0.0)
+            + (det["gpu"]["oodd_compute_utilization_pct"] or 0.0),
+            100.0,
+        )
+        det["gpu"]["total_memory_bandwidth_pct"] = min(
+            (det["gpu"]["primary_memory_bandwidth_pct"] or 0.0)
+            + (det["gpu"]["oodd_memory_bandwidth_pct"] or 0.0),
+            100.0,
+        )
 
-    return list(detectors.values()), loading_vram_bytes, loading_ram_bytes
+    return (
+        list(detectors.values()),
+        loading_vram_bytes,
+        loading_ram_bytes,
+        loading_gpu_compute_pct,
+        loading_gpu_memory_bw_pct,
+    )
 
 
 def _get_pod_ram_metrics(namespace: str) -> dict[str, int]:

--- a/app/metrics/resource_metrics.py
+++ b/app/metrics/resource_metrics.py
@@ -381,8 +381,9 @@ def _query_all_pod_gpus(inference_pods: list[tuple]) -> dict[str, dict | None]:
 def _build_gpu_summary(gpu_responses: dict[str, dict | None]) -> tuple[list, int, int, float, float]:
     """Aggregate GPU device observations across all queried pods.
 
-    Returns nested GPU device entries, aggregate VRAM bytes, and average
-    device-wide GPU utilization.
+    Returns (sorted_devices, total_vram_bytes, used_vram_bytes, avg_compute_pct,
+    avg_memory_bw_pct). The utilization averages are simple averages across
+    observed devices.
     """
     devices_by_key: dict[str, dict] = {}
     all_gpus_total = 0

--- a/app/metrics/resource_metrics.py
+++ b/app/metrics/resource_metrics.py
@@ -204,11 +204,17 @@ class ResourceMetricsCollector:
                         "total": gpu_compute_pct,
                         "detectors": detector_gpu_compute_pct,
                         "loading_detectors": loading_gpu_compute_pct,
+                        # Only inference pods are expected to consume GPU resources
+                        "edge_endpoint": 0.0,
+                        "other": 0.0,
                     },
                     "memory_bandwidth_pct": {
                         "total": gpu_memory_bw_pct,
                         "detectors": detector_gpu_memory_bw_pct,
                         "loading_detectors": loading_gpu_memory_bw_pct,
+                        # Only inference pods are expected to consume GPU resources
+                        "edge_endpoint": 0.0,
+                        "other": 0.0,
                     },
                     "devices": gpu_devices,
                 },
@@ -422,7 +428,7 @@ def _build_gpu_summary(gpu_responses: dict[str, dict | None]) -> tuple[list, int
                 existing_vram = existing["vram_bytes"]
                 existing_vram["total"] = max(existing_vram.get("total", 0), gpu_total)
                 existing_vram["used"] = max(existing_vram.get("used", 0), gpu_used)
-                existing_vram["free"] = max(existing_vram.get("free", 0), gpu_free)
+                existing_vram["free"] = max(0, existing_vram["total"] - existing_vram["used"])
                 existing["compute_utilization_pct"] = max(existing.get("compute_utilization_pct", 0.0), compute_pct)
                 existing["memory_bandwidth_pct"] = max(existing.get("memory_bandwidth_pct", 0.0), memory_bw_pct)
 

--- a/app/metrics/resource_metrics.py
+++ b/app/metrics/resource_metrics.py
@@ -1,13 +1,12 @@
 """Collects per-detector GPU, VRAM, RAM, and CPU usage for the status page.
 
 GPU and VRAM data comes from each inference pod's /v2/gpu-usage HTTP endpoint.
-RAM data comes from the Kubernetes Metrics Server (metrics.k8s.io/v1beta1).
-System-level RAM and CPU use the Kubernetes Node API so that the numbers match
-the kubelet's view of memory (which drives eviction decisions).
+RAM and CPU data come from the Kubernetes Metrics Server (metrics.k8s.io/v1beta1).
+System-level RAM and CPU capacity use the Kubernetes Node API.
 
 RAM used by non-inference pods in the edge namespace (the edge-endpoint
 server itself plus sidecars like splunk, opentelemetry-collector, etc.) is
-reported as a single `edge_endpoint_bytes` bucket on `system.ram`.
+reported as a single `edge_endpoint` bucket on `system.ram_bytes`.
 """
 
 import json
@@ -92,20 +91,20 @@ def _percentage(numerator: float, denominator: float) -> float:
 class ResourceMetricsCollector:
     """Collects GPU, VRAM, RAM, and CPU usage for status reporting.
 
-    The emitted payload is grouped by resource type at the system level and
-    per-detector so existing RAM/VRAM consumers remain stable while newer GPU
-    and CPU utilization metrics can be added.
+    The emitted payload uses explicit unit-bearing keys such as `ram_bytes`,
+    `vram_bytes`, and `cpu_utilization_pct`, with matching attribution buckets
+    at the system and detector levels.
     """
 
     def collect(self) -> dict:
         """Build the `/status/resources.json` payload.
 
         Returns a dict with two top-level keys:
-            - `system`: node-wide `cpu`, `ram`, `vram`, and `gpu` totals, plus
-              aggregate buckets for currently-loading detectors, edge-endpoint
-              platform overhead, and the list of observed GPU devices.
+            - `system`: node-wide CPU, RAM, and GPU resource buckets, including
+              currently-loading detectors, edge-endpoint platform overhead, and
+              GPU device inventory.
             - `detectors`: a list of per-detector entries, each with nested
-              `ram`, `vram`, and `gpu` objects.
+              CPU utilization, RAM bytes, and GPU resource objects.
 
         If called outside a Kubernetes cluster, returns `{"error": "..."}`.
         """
@@ -125,7 +124,7 @@ class ResourceMetricsCollector:
         if inference_pods:
             active_pods = _pick_active_pods(inference_pods)
             gpu_responses = _query_all_pod_gpus(inference_pods)
-            _, gpu_devices, total_vram, used_vram, gpu_compute_pct, gpu_memory_bw_pct = _build_gpu_summary(
+            gpu_devices, total_vram, used_vram, gpu_compute_pct, gpu_memory_bw_pct = _build_gpu_summary(
                 gpu_responses
             )
             (
@@ -222,8 +221,8 @@ def _get_node_resources(v1: "client.CoreV1Api") -> dict:
     """Get node RAM details and overall CPU utilization from Kubernetes APIs.
 
     Uses node capacity for RAM and CPU totals, and Metrics Server for current
-    usage. RAM keeps the existing detailed shape, while CPU is exposed as an
-    overall utilization percentage.
+    usage. CPU usage is stored internally as millicores so pod-level CPU can be
+    attributed as a percentage of node capacity.
     """
     try:
         node_name = os.environ.get("NODE_NAME")
@@ -375,11 +374,11 @@ def _query_all_pod_gpus(inference_pods: list[tuple]) -> dict[str, dict | None]:
     return {pod.metadata.name: data for pod, data in zip(pods, results)}
 
 
-def _build_gpu_summary(gpu_responses: dict[str, dict | None]) -> tuple[list, list, int, int, float, float]:
+def _build_gpu_summary(gpu_responses: dict[str, dict | None]) -> tuple[list, int, int, float, float]:
     """Aggregate GPU device observations across all queried pods.
 
-    Returns compatibility VRAM device entries, nested GPU device entries,
-    aggregate VRAM bytes, and average device-wide GPU utilization.
+    Returns nested GPU device entries, aggregate VRAM bytes, and average
+    device-wide GPU utilization.
     """
     devices_by_key: dict[str, dict] = {}
     all_gpus_total = 0
@@ -442,22 +441,13 @@ def _build_gpu_summary(gpu_responses: dict[str, dict | None]) -> tuple[list, lis
             g.get("name") or "",
         ),
     )
-    observed_gpus = [
-        {
-            "name": device["name"],
-            "index": device["index"],
-            "used_bytes": device["vram_bytes"]["used"],
-            "total_bytes": device["vram_bytes"]["total"],
-        }
-        for device in sorted_devices
-    ]
     if sorted_devices:
         compute_pct = sum(device["compute_utilization_pct"] for device in sorted_devices) / len(sorted_devices)
         memory_bw_pct = sum(device["memory_bandwidth_pct"] for device in sorted_devices) / len(sorted_devices)
     else:
         compute_pct = 0.0
         memory_bw_pct = 0.0
-    return observed_gpus, sorted_devices, all_gpus_total, all_gpus_used, compute_pct, memory_bw_pct
+    return sorted_devices, all_gpus_total, all_gpus_used, compute_pct, memory_bw_pct
 
 
 def _attribute_detector_resources(
@@ -467,11 +457,11 @@ def _attribute_detector_resources(
     pod_resources: dict[str, dict[str, float]],
     total_cpu_millicores: float,
 ) -> tuple[list, int, int, float, float, float]:
-    """Attribute VRAM, GPU utilization, and RAM to individual detectors or loading totals.
+    """Attribute CPU, RAM, and GPU resources to individual detectors or loading totals.
 
-    Returns detector entries, loading VRAM/RAM, and loading GPU utilization
-    totals. RAM/VRAM objects have primary, OODD, and total byte fields; GPU
-    objects have primary, OODD, and total utilization fields.
+    Returns detector entries, loading VRAM/RAM bytes, loading GPU utilization,
+    and loading CPU millicores. Detector resources are split into `primary`,
+    `oodd`, and `total` buckets.
     """
     detectors: dict[str, dict] = {}
     loading_vram_bytes = 0

--- a/app/metrics/resource_metrics.py
+++ b/app/metrics/resource_metrics.py
@@ -490,8 +490,7 @@ def _attribute_detector_resources(
             100.0,
         )
         det["gpu"]["total_memory_bandwidth_pct"] = min(
-            (det["gpu"]["primary_memory_bandwidth_pct"] or 0.0)
-            + (det["gpu"]["oodd_memory_bandwidth_pct"] or 0.0),
+            (det["gpu"]["primary_memory_bandwidth_pct"] or 0.0) + (det["gpu"]["oodd_memory_bandwidth_pct"] or 0.0),
             100.0,
         )
 

--- a/app/metrics/resource_metrics.py
+++ b/app/metrics/resource_metrics.py
@@ -124,9 +124,7 @@ class ResourceMetricsCollector:
         if inference_pods:
             active_pods = _pick_active_pods(inference_pods)
             gpu_responses = _query_all_pod_gpus(inference_pods)
-            gpu_devices, total_vram, used_vram, gpu_compute_pct, gpu_memory_bw_pct = _build_gpu_summary(
-                gpu_responses
-            )
+            gpu_devices, total_vram, used_vram, gpu_compute_pct, gpu_memory_bw_pct = _build_gpu_summary(gpu_responses)
             (
                 detectors,
                 loading_vram,

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -160,14 +160,15 @@ def build_resources(state):
     gpu_memory = min((num_detectors * 7.0) + loading_gpu_memory, 100.0) if has_gpu else 0.0
     detector_ram = sum(d["ram_bytes"]["total"] for d in detectors)
     detector_vram = sum(d["gpu"]["vram_bytes"]["total"] for d in detectors)
+    detector_cpu = sum(d["cpu_utilization_pct"]["total"] for d in detectors)
     return {
         "system": {
             "cpu_utilization_pct": {
                 "total": min(15.0 + num_detectors * 6.0 + (10.0 if loading else 0.0), 100.0),
-                "detectors": num_detectors * 1.5,
+                "detectors": detector_cpu,
                 "loading_detectors": 2.0 if loading else 0.0,
                 "edge_endpoint": 5.0,
-                "other": max(0.0, 10.0 + num_detectors * 4.5 + (8.0 if loading else 0.0)),
+                "other": max(0.0, 10.0 + num_detectors * 6.0 + (8.0 if loading else 0.0) - detector_cpu),
             },
             "ram_bytes": {
                 "total": total_ram,

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -161,14 +161,18 @@ def build_resources(state):
     detector_ram = sum(d["ram_bytes"]["total"] for d in detectors)
     detector_vram = sum(d["gpu"]["vram_bytes"]["total"] for d in detectors)
     detector_cpu = sum(d["cpu_utilization_pct"]["total"] for d in detectors)
+    loading_cpu = 2.0 if loading else 0.0
+    edge_endpoint_cpu = 5.0
+    other_cpu = max(0.0, 10.0 + num_detectors * 6.0 + (8.0 if loading else 0.0) - detector_cpu)
+    total_cpu = min(detector_cpu + loading_cpu + edge_endpoint_cpu + other_cpu, 100.0)
     return {
         "system": {
             "cpu_utilization_pct": {
-                "total": min(15.0 + num_detectors * 6.0 + (10.0 if loading else 0.0), 100.0),
+                "total": total_cpu,
                 "detectors": detector_cpu,
-                "loading_detectors": 2.0 if loading else 0.0,
-                "edge_endpoint": 5.0,
-                "other": max(0.0, 10.0 + num_detectors * 6.0 + (8.0 if loading else 0.0) - detector_cpu),
+                "loading_detectors": loading_cpu,
+                "edge_endpoint": edge_endpoint_cpu,
+                "other": other_cpu,
             },
             "ram_bytes": {
                 "total": total_ram,
@@ -192,11 +196,17 @@ def build_resources(state):
                     "total": gpu_compute,
                     "detectors": sum(d["gpu"]["compute_utilization_pct"]["total"] for d in detectors),
                     "loading_detectors": loading_gpu_compute,
+                    # Only inference pods are expected to consume GPU compute in the mock edge namespace.
+                    "edge_endpoint": 0.0,
+                    "other": 0.0,
                 },
                 "memory_bandwidth_pct": {
                     "total": gpu_memory,
                     "detectors": sum(d["gpu"]["memory_bandwidth_pct"]["total"] for d in detectors),
                     "loading_detectors": loading_gpu_memory,
+                    # Only inference pods are expected to consume GPU memory bandwidth in the mock edge namespace.
+                    "edge_endpoint": 0.0,
+                    "other": 0.0,
                 },
                 "devices": (
                     [

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -99,11 +99,17 @@ def build_resources(state):
     used_ram = EDGE_ENDPOINT_RAM_BYTES + OTHER_RAM_BASELINE_BYTES
     loading_vram = 0
     loading_ram = 0
+    loading_gpu_compute = 0.0
+    loading_gpu_memory = 0.0
 
     for i in range(num_detectors):
         d = _make_detector(i)
         det_vram = d["primary_vram"] + d["oodd_vram"]
         det_ram = d["primary_ram"] + d["oodd_ram"]
+        primary_gpu_compute = 8.0 + i * 3.0
+        oodd_gpu_compute = 3.0 + i
+        primary_gpu_memory = 5.0 + i * 2.0
+        oodd_gpu_memory = 2.0 + i
         detectors.append(
             {
                 "detector_id": d["id"],
@@ -117,6 +123,14 @@ def build_resources(state):
                     "oodd_bytes": d["oodd_vram"],
                     "total_bytes": det_vram,
                 },
+                "gpu": {
+                    "primary_compute_utilization_pct": primary_gpu_compute,
+                    "oodd_compute_utilization_pct": oodd_gpu_compute,
+                    "total_compute_utilization_pct": min(primary_gpu_compute + oodd_gpu_compute, 100.0),
+                    "primary_memory_bandwidth_pct": primary_gpu_memory,
+                    "oodd_memory_bandwidth_pct": oodd_gpu_memory,
+                    "total_memory_bandwidth_pct": min(primary_gpu_memory + oodd_gpu_memory, 100.0),
+                },
             }
         )
         used_vram += det_vram
@@ -125,12 +139,16 @@ def build_resources(state):
     if loading:
         loading_vram = 800_000_000
         loading_ram = 1_600_000_000
+        loading_gpu_compute = 12.0
+        loading_gpu_memory = 8.0
         used_vram += loading_vram
         used_ram += loading_ram
 
     has_gpu = num_detectors > 0 or loading
     vram_total_bytes = total_vram if has_gpu else 0
     vram_used_bytes = min(used_vram, total_vram) if has_gpu else 0
+    gpu_compute = min((num_detectors * 12.0) + loading_gpu_compute, 100.0) if has_gpu else 0.0
+    gpu_memory = min((num_detectors * 7.0) + loading_gpu_memory, 100.0) if has_gpu else 0.0
     observed_gpus = (
         [
             {
@@ -145,6 +163,9 @@ def build_resources(state):
     )
     return {
         "system": {
+            "cpu": {
+                "utilization_pct": min(15.0 + num_detectors * 6.0 + (10.0 if loading else 0.0), 100.0),
+            },
             "ram": {
                 "used_bytes": min(used_ram, total_ram),
                 "total_bytes": total_ram,
@@ -158,6 +179,26 @@ def build_resources(state):
                 "loading_detectors_bytes": loading_vram,
                 "edge_endpoint_bytes": 0,
                 "observed_gpus": observed_gpus,
+            },
+            "gpu": {
+                "compute_utilization_pct": gpu_compute,
+                "memory_bandwidth_pct": gpu_memory,
+                "loading_detectors_compute_utilization_pct": loading_gpu_compute,
+                "loading_detectors_memory_bandwidth_pct": loading_gpu_memory,
+                "devices": [
+                    {
+                        "index": 0,
+                        "uuid": "GPU-mock-0",
+                        "name": "Mock GPU",
+                        "vram_total_bytes": vram_total_bytes,
+                        "vram_used_bytes": vram_used_bytes,
+                        "vram_free_bytes": max(vram_total_bytes - vram_used_bytes, 0),
+                        "compute_utilization_pct": gpu_compute,
+                        "memory_bandwidth_pct": gpu_memory,
+                    }
+                ]
+                if has_gpu
+                else [],
             },
         },
         "detectors": detectors,

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -185,20 +185,22 @@ def build_resources(state):
                 "memory_bandwidth_pct": gpu_memory,
                 "loading_detectors_compute_utilization_pct": loading_gpu_compute,
                 "loading_detectors_memory_bandwidth_pct": loading_gpu_memory,
-                "devices": [
-                    {
-                        "index": 0,
-                        "uuid": "GPU-mock-0",
-                        "name": "Mock GPU",
-                        "vram_total_bytes": vram_total_bytes,
-                        "vram_used_bytes": vram_used_bytes,
-                        "vram_free_bytes": max(vram_total_bytes - vram_used_bytes, 0),
-                        "compute_utilization_pct": gpu_compute,
-                        "memory_bandwidth_pct": gpu_memory,
-                    }
-                ]
-                if has_gpu
-                else [],
+                "devices": (
+                    [
+                        {
+                            "index": 0,
+                            "uuid": "GPU-mock-0",
+                            "name": "Mock GPU",
+                            "vram_total_bytes": vram_total_bytes,
+                            "vram_used_bytes": vram_used_bytes,
+                            "vram_free_bytes": max(vram_total_bytes - vram_used_bytes, 0),
+                            "compute_utilization_pct": gpu_compute,
+                            "memory_bandwidth_pct": gpu_memory,
+                        }
+                    ]
+                    if has_gpu
+                    else []
+                ),
             },
         },
         "detectors": detectors,

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -197,22 +197,24 @@ def build_resources(state):
                     "detectors": sum(d["gpu"]["memory_bandwidth_pct"]["total"] for d in detectors),
                     "loading_detectors": loading_gpu_memory,
                 },
-                "devices": [
-                    {
-                        "index": 0,
-                        "uuid": "GPU-mock-0",
-                        "name": "Mock GPU",
-                        "vram_bytes": {
-                            "total": vram_total_bytes,
-                            "used": vram_used_bytes,
-                            "free": max(vram_total_bytes - vram_used_bytes, 0),
-                        },
-                        "compute_utilization_pct": gpu_compute,
-                        "memory_bandwidth_pct": gpu_memory,
-                    }
-                ]
-                if has_gpu
-                else [],
+                "devices": (
+                    [
+                        {
+                            "index": 0,
+                            "uuid": "GPU-mock-0",
+                            "name": "Mock GPU",
+                            "vram_bytes": {
+                                "total": vram_total_bytes,
+                                "used": vram_used_bytes,
+                                "free": max(vram_total_bytes - vram_used_bytes, 0),
+                            },
+                            "compute_utilization_pct": gpu_compute,
+                            "memory_bandwidth_pct": gpu_memory,
+                        }
+                    ]
+                    if has_gpu
+                    else []
+                ),
             },
         },
         "detectors": detectors,

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -113,23 +113,32 @@ def build_resources(state):
         detectors.append(
             {
                 "detector_id": d["id"],
-                "ram": {
-                    "primary_bytes": d["primary_ram"],
-                    "oodd_bytes": d["oodd_ram"],
-                    "total_bytes": det_ram,
+                "cpu_utilization_pct": {
+                    "primary": 1.0 + i,
+                    "oodd": 0.5 + i,
+                    "total": 1.5 + i * 2,
                 },
-                "vram": {
-                    "primary_bytes": d["primary_vram"],
-                    "oodd_bytes": d["oodd_vram"],
-                    "total_bytes": det_vram,
+                "ram_bytes": {
+                    "primary": d["primary_ram"],
+                    "oodd": d["oodd_ram"],
+                    "total": det_ram,
                 },
                 "gpu": {
-                    "primary_compute_utilization_pct": primary_gpu_compute,
-                    "oodd_compute_utilization_pct": oodd_gpu_compute,
-                    "total_compute_utilization_pct": min(primary_gpu_compute + oodd_gpu_compute, 100.0),
-                    "primary_memory_bandwidth_pct": primary_gpu_memory,
-                    "oodd_memory_bandwidth_pct": oodd_gpu_memory,
-                    "total_memory_bandwidth_pct": min(primary_gpu_memory + oodd_gpu_memory, 100.0),
+                    "vram_bytes": {
+                        "primary": d["primary_vram"],
+                        "oodd": d["oodd_vram"],
+                        "total": det_vram,
+                    },
+                    "compute_utilization_pct": {
+                        "primary": primary_gpu_compute,
+                        "oodd": oodd_gpu_compute,
+                        "total": min(primary_gpu_compute + oodd_gpu_compute, 100.0),
+                    },
+                    "memory_bandwidth_pct": {
+                        "primary": primary_gpu_memory,
+                        "oodd": oodd_gpu_memory,
+                        "total": min(primary_gpu_memory + oodd_gpu_memory, 100.0),
+                    },
                 },
             }
         )
@@ -149,50 +158,55 @@ def build_resources(state):
     vram_used_bytes = min(used_vram, total_vram) if has_gpu else 0
     gpu_compute = min((num_detectors * 12.0) + loading_gpu_compute, 100.0) if has_gpu else 0.0
     gpu_memory = min((num_detectors * 7.0) + loading_gpu_memory, 100.0) if has_gpu else 0.0
-    observed_gpus = (
-        [
-            {
-                "name": "Mock GPU",
-                "index": 0,
-                "used_bytes": vram_used_bytes,
-                "total_bytes": vram_total_bytes,
-            }
-        ]
-        if has_gpu
-        else []
-    )
+    detector_ram = sum(d["ram_bytes"]["total"] for d in detectors)
+    detector_vram = sum(d["gpu"]["vram_bytes"]["total"] for d in detectors)
     return {
         "system": {
-            "cpu": {
-                "utilization_pct": min(15.0 + num_detectors * 6.0 + (10.0 if loading else 0.0), 100.0),
+            "cpu_utilization_pct": {
+                "total": min(15.0 + num_detectors * 6.0 + (10.0 if loading else 0.0), 100.0),
+                "detectors": num_detectors * 1.5,
+                "loading_detectors": 2.0 if loading else 0.0,
+                "edge_endpoint": 5.0,
+                "other": max(0.0, 10.0 + num_detectors * 4.5 + (8.0 if loading else 0.0)),
             },
-            "ram": {
-                "used_bytes": min(used_ram, total_ram),
-                "total_bytes": total_ram,
-                "loading_detectors_bytes": loading_ram,
-                "edge_endpoint_bytes": EDGE_ENDPOINT_RAM_BYTES,
+            "ram_bytes": {
+                "total": total_ram,
+                "used": min(used_ram, total_ram),
+                "detectors": detector_ram,
+                "loading_detectors": loading_ram,
+                "edge_endpoint": EDGE_ENDPOINT_RAM_BYTES,
+                "other": OTHER_RAM_BASELINE_BYTES,
                 "eviction_threshold_pct": state["eviction"],
             },
-            "vram": {
-                "used_bytes": vram_used_bytes,
-                "total_bytes": vram_total_bytes,
-                "loading_detectors_bytes": loading_vram,
-                "edge_endpoint_bytes": 0,
-                "observed_gpus": observed_gpus,
-            },
             "gpu": {
-                "compute_utilization_pct": gpu_compute,
-                "memory_bandwidth_pct": gpu_memory,
-                "loading_detectors_compute_utilization_pct": loading_gpu_compute,
-                "loading_detectors_memory_bandwidth_pct": loading_gpu_memory,
+                "vram_bytes": {
+                    "total": vram_total_bytes,
+                    "used": vram_used_bytes,
+                    "detectors": detector_vram,
+                    "loading_detectors": loading_vram,
+                    "edge_endpoint": 0,
+                    "other": max(0, vram_used_bytes - detector_vram - loading_vram),
+                },
+                "compute_utilization_pct": {
+                    "total": gpu_compute,
+                    "detectors": sum(d["gpu"]["compute_utilization_pct"]["total"] for d in detectors),
+                    "loading_detectors": loading_gpu_compute,
+                },
+                "memory_bandwidth_pct": {
+                    "total": gpu_memory,
+                    "detectors": sum(d["gpu"]["memory_bandwidth_pct"]["total"] for d in detectors),
+                    "loading_detectors": loading_gpu_memory,
+                },
                 "devices": [
                     {
                         "index": 0,
                         "uuid": "GPU-mock-0",
                         "name": "Mock GPU",
-                        "vram_total_bytes": vram_total_bytes,
-                        "vram_used_bytes": vram_used_bytes,
-                        "vram_free_bytes": max(vram_total_bytes - vram_used_bytes, 0),
+                        "vram_bytes": {
+                            "total": vram_total_bytes,
+                            "used": vram_used_bytes,
+                            "free": max(vram_total_bytes - vram_used_bytes, 0),
+                        },
                         "compute_utilization_pct": gpu_compute,
                         "memory_bandwidth_pct": gpu_memory,
                     }

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -156,11 +156,13 @@ def build_resources(state):
     has_gpu = num_detectors > 0 or loading
     vram_total_bytes = total_vram if has_gpu else 0
     vram_used_bytes = min(used_vram, total_vram) if has_gpu else 0
-    gpu_compute = min((num_detectors * 12.0) + loading_gpu_compute, 100.0) if has_gpu else 0.0
-    gpu_memory = min((num_detectors * 7.0) + loading_gpu_memory, 100.0) if has_gpu else 0.0
     detector_ram = sum(d["ram_bytes"]["total"] for d in detectors)
     detector_vram = sum(d["gpu"]["vram_bytes"]["total"] for d in detectors)
     detector_cpu = sum(d["cpu_utilization_pct"]["total"] for d in detectors)
+    detector_gpu_compute = sum(d["gpu"]["compute_utilization_pct"]["total"] for d in detectors)
+    detector_gpu_memory = sum(d["gpu"]["memory_bandwidth_pct"]["total"] for d in detectors)
+    gpu_compute = min(detector_gpu_compute + loading_gpu_compute, 100.0) if has_gpu else 0.0
+    gpu_memory = min(detector_gpu_memory + loading_gpu_memory, 100.0) if has_gpu else 0.0
     loading_cpu = 2.0 if loading else 0.0
     edge_endpoint_cpu = 5.0
     other_cpu = max(0.0, 10.0 + num_detectors * 6.0 + (8.0 if loading else 0.0) - detector_cpu)
@@ -194,7 +196,7 @@ def build_resources(state):
                 },
                 "compute_utilization_pct": {
                     "total": gpu_compute,
-                    "detectors": sum(d["gpu"]["compute_utilization_pct"]["total"] for d in detectors),
+                    "detectors": detector_gpu_compute,
                     "loading_detectors": loading_gpu_compute,
                     # Only inference pods are expected to consume GPU compute in the mock edge namespace.
                     "edge_endpoint": 0.0,
@@ -202,7 +204,7 @@ def build_resources(state):
                 },
                 "memory_bandwidth_pct": {
                     "total": gpu_memory,
-                    "detectors": sum(d["gpu"]["memory_bandwidth_pct"]["total"] for d in detectors),
+                    "detectors": detector_gpu_memory,
                     "loading_detectors": loading_gpu_memory,
                     # Only inference pods are expected to consume GPU memory bandwidth in the mock edge namespace.
                     "edge_endpoint": 0.0,

--- a/app/status_monitor/frontend/src/components/CapacitySummary.jsx
+++ b/app/status_monitor/frontend/src/components/CapacitySummary.jsx
@@ -25,23 +25,24 @@ export function GpuCapacitySummary({ observedGpus, totalBytes, usedBytes }) {
 
   if (gpus.length === 1) {
     const gpu = gpus[0];
+    const vram = gpu.vram_bytes || {};
     return (
       <Text size="sm" fw={500}>
-        {gpu.name} ({formatBytes(gpu.used_bytes)} / {formatBytes(gpu.total_bytes)},{" "}
-        {formatPctInt(gpu.used_bytes, gpu.total_bytes)})
+        {gpu.name} ({formatBytes(vram.used)} / {formatBytes(vram.total)},{" "}
+        {formatPctInt(vram.used, vram.total)})
       </Text>
     );
   }
 
-  const totalGpuBytes = gpus.reduce((sum, gpu) => sum + (gpu.total_bytes || 0), 0);
-  const usedGpuBytes = gpus.reduce((sum, gpu) => sum + (gpu.used_bytes || 0), 0);
+  const totalGpuBytes = gpus.reduce((sum, gpu) => sum + (gpu.vram_bytes?.total || 0), 0);
+  const usedGpuBytes = gpus.reduce((sum, gpu) => sum + (gpu.vram_bytes?.used || 0), 0);
   return (
     <Stack gap={2}>
       <InlineSummary usedBytes={usedGpuBytes} totalBytes={totalGpuBytes} />
       {gpus.map((gpu, i) => (
         <Text key={`${gpu.name}-${i}`} size="xs" c="gray.8">
-          GPU {gpu.index ?? i}: {gpu.name} ({formatBytes(gpu.used_bytes)} /{" "}
-          {formatBytes(gpu.total_bytes)})
+          GPU {gpu.index ?? i}: {gpu.name} ({formatBytes(gpu.vram_bytes?.used)} /{" "}
+          {formatBytes(gpu.vram_bytes?.total)})
         </Text>
       ))}
     </Stack>

--- a/app/status_monitor/frontend/src/components/ResourceUsage.jsx
+++ b/app/status_monitor/frontend/src/components/ResourceUsage.jsx
@@ -53,8 +53,8 @@ function prepareDetectors(resourceData, detectorDetails) {
  */
 function buildLegendRows({ detectors, nameMap, colorMap, vram, ram }) {
   const detectorRows = detectors.map((det) => {
-    const detVram = det.vram?.total_bytes || 0;
-    const detRam = det.ram?.total_bytes || 0;
+    const detVram = det.gpu?.vram_bytes?.total || 0;
+    const detRam = det.ram_bytes?.total || 0;
     return {
       sliceKey: `det:${det.detector_id}`,
       detectorId: det.detector_id,
@@ -213,23 +213,24 @@ export default function ResourceUsage({ resourceData, detectorDetails, loading }
     );
   }
 
-  const systemVram = resourceData.system?.vram || {};
-  const systemRam = resourceData.system?.ram || {};
-  const observedGpus = systemVram.observed_gpus || [];
+  const systemGpu = resourceData.system?.gpu || {};
+  const systemVram = systemGpu.vram_bytes || {};
+  const systemRam = resourceData.system?.ram_bytes || {};
+  const observedGpus = systemGpu.devices || [];
   const hasVram = observedGpus.length > 0;
-  const hasRam = (systemRam.total_bytes || 0) > 0;
+  const hasRam = (systemRam.total || 0) > 0;
 
   const vram = {
-    total: systemVram.total_bytes || 0,
-    used: systemVram.used_bytes || 0,
-    loading: systemVram.loading_detectors_bytes || 0,
-    edgeEndpoint: systemVram.edge_endpoint_bytes || 0,
+    total: systemVram.total || 0,
+    used: systemVram.used || 0,
+    loading: systemVram.loading_detectors || 0,
+    edgeEndpoint: systemVram.edge_endpoint || 0,
   };
   const ram = {
-    total: systemRam.total_bytes || 0,
-    used: systemRam.used_bytes || 0,
-    loading: systemRam.loading_detectors_bytes || 0,
-    edgeEndpoint: systemRam.edge_endpoint_bytes || 0,
+    total: systemRam.total || 0,
+    used: systemRam.used || 0,
+    loading: systemRam.loading_detectors || 0,
+    edgeEndpoint: systemRam.edge_endpoint || 0,
     evictionPct: systemRam.eviction_threshold_pct ?? null,
   };
 
@@ -246,7 +247,7 @@ export default function ResourceUsage({ resourceData, detectorDetails, loading }
     loadingBytes: hasVram ? vram.loading : 0,
     edgeEndpointBytes: hasVram ? vram.edgeEndpoint : 0,
     colorMap,
-    resourceKey: "vram",
+    resourceKey: "gpu.vram_bytes",
     resourceLabel: "VRAM",
   });
 
@@ -259,7 +260,7 @@ export default function ResourceUsage({ resourceData, detectorDetails, loading }
         loadingBytes: ram.loading,
         edgeEndpointBytes: ram.edgeEndpoint,
         colorMap,
-        resourceKey: "ram",
+        resourceKey: "ram_bytes",
         resourceLabel: "RAM",
       })
     : null;

--- a/app/status_monitor/frontend/src/components/chartUtils.js
+++ b/app/status_monitor/frontend/src/components/chartUtils.js
@@ -66,8 +66,8 @@ export function formatPctInt(bytes, totalBytes) {
  * relies on for stable positional animation.
  *
  * `resourceKey` selects which sub-object on each detector to read (e.g.
- * "vram" or "ram"); each detector is expected to have that key with a
- * nested `total_bytes` field.
+ * "gpu.vram_bytes" or "ram_bytes"); each detector is expected to have that
+ * key with a nested `total` field.
  */
 export function buildSlices({
   detectors,
@@ -84,8 +84,10 @@ export function buildSlices({
   const slices = [];
   let accountedBytes = 0;
 
+  const getResource = (det) => resourceKey.split(".").reduce((value, key) => value?.[key], det);
+
   for (const det of detectors) {
-    const bytes = det[resourceKey]?.total_bytes || 0;
+    const bytes = getResource(det)?.total || 0;
     accountedBytes += bytes;
     slices.push({
       sliceKey: `det:${det.detector_id}`,

--- a/test/metrics/test_resource_metrics.py
+++ b/test/metrics/test_resource_metrics.py
@@ -211,7 +211,11 @@ class TestGetNodeResources:
 
         assert result["ram"]["total"] == 4 * 1024**3
         assert result["ram"]["used"] == 2 * 1024**3
-        assert result["cpu"] == {"utilization_pct": 25.0}
+        assert result["cpu"] == {
+            "utilization_pct": 25.0,
+            "used_millicores": 1000.0,
+            "total_millicores": 4000.0,
+        }
 
 
 class TestFindInferencePods:
@@ -309,95 +313,106 @@ class TestPickActivePods:
 
 class TestAttributeDetectorResources:
     def test_active_pod_routes_to_detector_slot(self):
-        """An active pod's RAM/VRAM lands in its detector's primary or oodd slot, and total_bytes sums both."""
+        """An active pod's RAM/VRAM lands in its detector's primary or OODD slot, and totals sum both."""
         primary = _make_inference_pod("primary-pod")
         oodd = _make_inference_pod("oodd-pod", is_oodd=True)
-        detectors, loading_vram, loading_ram, loading_gpu_compute, loading_gpu_memory = _attribute_detector_resources(
+        detectors, loading_vram, loading_ram, loading_gpu_compute, loading_gpu_memory, loading_cpu = _attribute_detector_resources(
             inference_pods=[(primary, DET_A, False, True), (oodd, DET_A, True, True)],
             active_pods={"primary-pod", "oodd-pod"},
             gpu_responses={
                 "primary-pod": _gpu_process(100, compute_pct=10, memory_bw_pct=8),
                 "oodd-pod": _gpu_process(50, compute_pct=5, memory_bw_pct=3),
             },
-            ram_by_pod={"primary-pod": 1000, "oodd-pod": 500},
+            pod_resources={
+                "primary-pod": {"ram_bytes": 1000, "cpu_millicores": 100},
+                "oodd-pod": {"ram_bytes": 500, "cpu_millicores": 50},
+            },
+            total_cpu_millicores=1000,
         )
 
         assert loading_vram == 0 and loading_ram == 0
         assert loading_gpu_compute == 0.0 and loading_gpu_memory == 0.0
+        assert loading_cpu == 0.0
         assert len(detectors) == 1
         det = detectors[0]
         assert det["detector_id"] == DET_A
-        assert det["vram"] == {"primary_bytes": 100, "oodd_bytes": 50, "total_bytes": 150}
-        assert det["ram"] == {"primary_bytes": 1000, "oodd_bytes": 500, "total_bytes": 1500}
+        assert det["cpu_utilization_pct"] == {"primary": 10.0, "oodd": 5.0, "total": 15.0}
+        assert det["gpu"]["vram_bytes"] == {"primary": 100, "oodd": 50, "total": 150}
+        assert det["ram_bytes"] == {"primary": 1000, "oodd": 500, "total": 1500}
         assert det["gpu"] == {
-            "primary_compute_utilization_pct": 10.0,
-            "oodd_compute_utilization_pct": 5.0,
-            "total_compute_utilization_pct": 15.0,
-            "primary_memory_bandwidth_pct": 8.0,
-            "oodd_memory_bandwidth_pct": 3.0,
-            "total_memory_bandwidth_pct": 11.0,
+            "vram_bytes": {"primary": 100, "oodd": 50, "total": 150},
+            "compute_utilization_pct": {"primary": 10.0, "oodd": 5.0, "total": 15.0},
+            "memory_bandwidth_pct": {"primary": 8.0, "oodd": 3.0, "total": 11.0},
         }
 
     def test_only_primary_leaves_oodd_slot_none(self):
         """A detector with only a primary pod has oodd_bytes=None and total_bytes equal to primary."""
         primary = _make_inference_pod("primary-pod")
         inference_pods = [(primary, DET_A, False, True)]
-        detectors, _, _, _, _ = _attribute_detector_resources(
+        detectors, _, _, _, _, _ = _attribute_detector_resources(
             inference_pods,
             active_pods={"primary-pod"},
             gpu_responses={"primary-pod": _gpu_process(100)},
-            ram_by_pod={"primary-pod": 1000},
+            pod_resources={"primary-pod": {"ram_bytes": 1000, "cpu_millicores": 0}},
+            total_cpu_millicores=1000,
         )
-        assert detectors[0]["vram"] == {"primary_bytes": 100, "oodd_bytes": None, "total_bytes": 100}
-        assert detectors[0]["ram"] == {"primary_bytes": 1000, "oodd_bytes": None, "total_bytes": 1000}
+        assert detectors[0]["gpu"]["vram_bytes"] == {"primary": 100, "oodd": None, "total": 100}
+        assert detectors[0]["ram_bytes"] == {"primary": 1000, "oodd": None, "total": 1000}
 
     def test_multiple_detectors_produce_separate_entries(self):
         """Pods belonging to different detectors get their own entries in the output."""
         a = _make_inference_pod("a")
         b = _make_inference_pod("b")
         inference_pods = [(a, DET_A, False, True), (b, DET_B, False, True)]
-        detectors, _, _, _, _ = _attribute_detector_resources(
+        detectors, _, _, _, _, _ = _attribute_detector_resources(
             inference_pods,
             active_pods={"a", "b"},
             gpu_responses={"a": _gpu_process(100), "b": _gpu_process(200)},
-            ram_by_pod={"a": 1000, "b": 2000},
+            pod_resources={"a": {"ram_bytes": 1000, "cpu_millicores": 0}, "b": {"ram_bytes": 2000, "cpu_millicores": 0}},
+            total_cpu_millicores=1000,
         )
         by_id = {d["detector_id"]: d for d in detectors}
         assert set(by_id) == {DET_A, DET_B}
-        assert by_id[DET_A]["vram"]["total_bytes"] == 100
-        assert by_id[DET_B]["vram"]["total_bytes"] == 200
+        assert by_id[DET_A]["gpu"]["vram_bytes"]["total"] == 100
+        assert by_id[DET_B]["gpu"]["vram_bytes"]["total"] == 200
 
     def test_inactive_pod_routes_to_loading(self):
         """A non-active pod's RAM/VRAM rolls into the loading totals, not into a detector slot."""
         active_pod = _make_inference_pod("active")
         loading_pod = _make_inference_pod("loading")
-        detectors, loading_vram, loading_ram, loading_gpu_compute, loading_gpu_memory = _attribute_detector_resources(
+        detectors, loading_vram, loading_ram, loading_gpu_compute, loading_gpu_memory, loading_cpu = _attribute_detector_resources(
             inference_pods=[(active_pod, DET_A, False, True), (loading_pod, DET_A, False, False)],
             active_pods={"active"},
             gpu_responses={
                 "active": _gpu_process(100),
                 "loading": _gpu_process(800, compute_pct=30, memory_bw_pct=12),
             },
-            ram_by_pod={"active": 1000, "loading": 5000},
+            pod_resources={
+                "active": {"ram_bytes": 1000, "cpu_millicores": 100},
+                "loading": {"ram_bytes": 5000, "cpu_millicores": 250},
+            },
+            total_cpu_millicores=1000,
         )
 
         assert loading_vram == 800 and loading_ram == 5000
         assert loading_gpu_compute == 30.0 and loading_gpu_memory == 12.0
+        assert loading_cpu == 250.0
         assert len(detectors) == 1
-        assert detectors[0]["vram"]["primary_bytes"] == 100
-        assert detectors[0]["ram"]["primary_bytes"] == 1000
+        assert detectors[0]["gpu"]["vram_bytes"]["primary"] == 100
+        assert detectors[0]["ram_bytes"]["primary"] == 1000
 
     def test_missing_gpu_data_yields_zero_vram(self):
         """A pod with no GPU response contributes 0 VRAM but still picks up RAM from Metrics Server."""
         pod = _make_inference_pod("p")
-        detectors, _, _, _, _ = _attribute_detector_resources(
+        detectors, _, _, _, _, _ = _attribute_detector_resources(
             inference_pods=[(pod, DET_A, False, True)],
             active_pods={"p"},
             gpu_responses={},
-            ram_by_pod={"p": 1000},
+            pod_resources={"p": {"ram_bytes": 1000, "cpu_millicores": 0}},
+            total_cpu_millicores=1000,
         )
-        assert detectors[0]["vram"]["primary_bytes"] == 0
-        assert detectors[0]["ram"]["primary_bytes"] == 1000
+        assert detectors[0]["gpu"]["vram_bytes"]["primary"] == 0
+        assert detectors[0]["ram_bytes"]["primary"] == 1000
 
 
 class TestBuildGpuSummary:
@@ -407,7 +422,7 @@ class TestBuildGpuSummary:
         observed, devices, total, used, compute_pct, memory_bw_pct = _build_gpu_summary(responses)
         assert total == 1000 and used == 200
         assert observed == [{"name": "NVIDIA A10", "index": 0, "used_bytes": 200, "total_bytes": 1000}]
-        assert devices[0]["vram_used_bytes"] == 200
+        assert devices[0]["vram_bytes"]["used"] == 200
         assert compute_pct == 20.0 and memory_bw_pct == 10.0
 
     def test_two_pods_same_gpu_dedupes_by_uuid(self):

--- a/test/metrics/test_resource_metrics.py
+++ b/test/metrics/test_resource_metrics.py
@@ -441,6 +441,7 @@ class TestBuildGpuSummary:
         assert total == 1000 and used == 300
         assert len(devices) == 1
         assert devices[0]["vram_bytes"]["used"] == 300
+        assert devices[0]["vram_bytes"]["free"] == 700
         assert devices[0]["compute_utilization_pct"] == 30.0
         assert compute_pct == 30.0
 

--- a/test/metrics/test_resource_metrics.py
+++ b/test/metrics/test_resource_metrics.py
@@ -316,18 +316,20 @@ class TestAttributeDetectorResources:
         """An active pod's RAM/VRAM lands in its detector's primary or OODD slot, and totals sum both."""
         primary = _make_inference_pod("primary-pod")
         oodd = _make_inference_pod("oodd-pod", is_oodd=True)
-        detectors, loading_vram, loading_ram, loading_gpu_compute, loading_gpu_memory, loading_cpu = _attribute_detector_resources(
-            inference_pods=[(primary, DET_A, False, True), (oodd, DET_A, True, True)],
-            active_pods={"primary-pod", "oodd-pod"},
-            gpu_responses={
-                "primary-pod": _gpu_process(100, compute_pct=10, memory_bw_pct=8),
-                "oodd-pod": _gpu_process(50, compute_pct=5, memory_bw_pct=3),
-            },
-            pod_resources={
-                "primary-pod": {"ram_bytes": 1000, "cpu_millicores": 100},
-                "oodd-pod": {"ram_bytes": 500, "cpu_millicores": 50},
-            },
-            total_cpu_millicores=1000,
+        detectors, loading_vram, loading_ram, loading_gpu_compute, loading_gpu_memory, loading_cpu = (
+            _attribute_detector_resources(
+                inference_pods=[(primary, DET_A, False, True), (oodd, DET_A, True, True)],
+                active_pods={"primary-pod", "oodd-pod"},
+                gpu_responses={
+                    "primary-pod": _gpu_process(100, compute_pct=10, memory_bw_pct=8),
+                    "oodd-pod": _gpu_process(50, compute_pct=5, memory_bw_pct=3),
+                },
+                pod_resources={
+                    "primary-pod": {"ram_bytes": 1000, "cpu_millicores": 100},
+                    "oodd-pod": {"ram_bytes": 500, "cpu_millicores": 50},
+                },
+                total_cpu_millicores=1000,
+            )
         )
 
         assert loading_vram == 0 and loading_ram == 0
@@ -368,7 +370,10 @@ class TestAttributeDetectorResources:
             inference_pods,
             active_pods={"a", "b"},
             gpu_responses={"a": _gpu_process(100), "b": _gpu_process(200)},
-            pod_resources={"a": {"ram_bytes": 1000, "cpu_millicores": 0}, "b": {"ram_bytes": 2000, "cpu_millicores": 0}},
+            pod_resources={
+                "a": {"ram_bytes": 1000, "cpu_millicores": 0},
+                "b": {"ram_bytes": 2000, "cpu_millicores": 0},
+            },
             total_cpu_millicores=1000,
         )
         by_id = {d["detector_id"]: d for d in detectors}
@@ -380,18 +385,20 @@ class TestAttributeDetectorResources:
         """A non-active pod's RAM/VRAM rolls into the loading totals, not into a detector slot."""
         active_pod = _make_inference_pod("active")
         loading_pod = _make_inference_pod("loading")
-        detectors, loading_vram, loading_ram, loading_gpu_compute, loading_gpu_memory, loading_cpu = _attribute_detector_resources(
-            inference_pods=[(active_pod, DET_A, False, True), (loading_pod, DET_A, False, False)],
-            active_pods={"active"},
-            gpu_responses={
-                "active": _gpu_process(100),
-                "loading": _gpu_process(800, compute_pct=30, memory_bw_pct=12),
-            },
-            pod_resources={
-                "active": {"ram_bytes": 1000, "cpu_millicores": 100},
-                "loading": {"ram_bytes": 5000, "cpu_millicores": 250},
-            },
-            total_cpu_millicores=1000,
+        detectors, loading_vram, loading_ram, loading_gpu_compute, loading_gpu_memory, loading_cpu = (
+            _attribute_detector_resources(
+                inference_pods=[(active_pod, DET_A, False, True), (loading_pod, DET_A, False, False)],
+                active_pods={"active"},
+                gpu_responses={
+                    "active": _gpu_process(100),
+                    "loading": _gpu_process(800, compute_pct=30, memory_bw_pct=12),
+                },
+                pod_resources={
+                    "active": {"ram_bytes": 1000, "cpu_millicores": 100},
+                    "loading": {"ram_bytes": 5000, "cpu_millicores": 250},
+                },
+                total_cpu_millicores=1000,
+            )
         )
 
         assert loading_vram == 800 and loading_ram == 5000

--- a/test/metrics/test_resource_metrics.py
+++ b/test/metrics/test_resource_metrics.py
@@ -6,7 +6,7 @@ attribution rules).
 
 import json
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from kubernetes import client
 
@@ -14,7 +14,9 @@ from app.metrics.resource_metrics import (
     _attribute_detector_resources,
     _build_gpu_summary,
     _find_inference_pods,
+    _get_node_resources,
     _parse_eviction_threshold,
+    _parse_k8s_cpu,
     _parse_k8s_memory,
     _pick_active_pods,
 )
@@ -72,10 +74,37 @@ def _make_node(node_args: list[str] | None) -> MagicMock:
 
 
 def _gpu_device(
-    name: str = "NVIDIA A10", index: int = 0, total: int = 1000, used: int = 100, uuid: str | None = "GPU-uuid-0"
+    name: str = "NVIDIA A10",
+    index: int = 0,
+    total: int = 1000,
+    used: int = 100,
+    free: int = 900,
+    uuid: str | None = "GPU-uuid-0",
+    compute_pct: float = 0.0,
+    memory_bw_pct: float = 0.0,
 ) -> dict:
-    """Build a single device entry as it appears in the /gpu-usage response."""
-    return {"name": name, "index": index, "total_bytes": total, "used_bytes": used, "uuid": uuid}
+    """Build a single device entry as it appears in the /v2/gpu-usage response."""
+    return {
+        "name": name,
+        "index": index,
+        "vram_total_bytes": total,
+        "vram_used_bytes": used,
+        "vram_free_bytes": free,
+        "uuid": uuid,
+        "compute_utilization_pct": compute_pct,
+        "memory_bandwidth_pct": memory_bw_pct,
+    }
+
+
+def _gpu_process(vram: int, compute_pct: float = 0.0, memory_bw_pct: float = 0.0) -> dict:
+    """Build a process entry as it appears in the /v2/gpu-usage response."""
+    return {
+        "process": {
+            "vram_used_bytes": vram,
+            "compute_utilization_pct": compute_pct,
+            "memory_bandwidth_pct": memory_bw_pct,
+        }
+    }
 
 
 class TestParseK8sMemory:
@@ -104,6 +133,27 @@ class TestParseK8sMemory:
         """Garbage input returns 0 instead of raising."""
         assert _parse_k8s_memory("not-a-number") == 0
         assert _parse_k8s_memory("") == 0
+
+
+class TestParseK8sCpu:
+    def test_cores(self):
+        """Bare CPU values are cores and convert to millicores."""
+        assert _parse_k8s_cpu("2") == 2000.0
+        assert _parse_k8s_cpu("1.5") == 1500.0
+
+    def test_millicores(self):
+        """The `m` suffix is already in millicores."""
+        assert _parse_k8s_cpu("250m") == 250.0
+
+    def test_micro_and_nanocores(self):
+        """Metrics Server sub-millicore quantities are converted without truncation."""
+        assert _parse_k8s_cpu("1000u") == 1.0
+        assert _parse_k8s_cpu("1000000n") == 1.0
+
+    def test_unparseable_returns_zero(self):
+        """Garbage input returns 0 instead of raising."""
+        assert _parse_k8s_cpu("not-a-number") == 0.0
+        assert _parse_k8s_cpu("") == 0.0
 
 
 class TestParseEvictionThreshold:
@@ -135,6 +185,33 @@ class TestParseEvictionThreshold:
     def test_missing_annotation_returns_none(self):
         """Non-k3s nodes (no annotation) yield None rather than crashing."""
         assert _parse_eviction_threshold(_make_node(None)) is None
+
+
+class TestGetNodeResources:
+    def test_cpu_utilization_uses_capacity_denominator(self, monkeypatch):
+        """Node CPU utilization is computed from Metrics Server usage over node capacity."""
+        monkeypatch.setenv("NODE_NAME", "edge-node")
+        node = _make_node(None)
+        node.metadata.name = "edge-node"
+        node.status.capacity = {"memory": "4Gi", "cpu": "4"}
+        v1 = MagicMock()
+        v1.read_node.return_value = node
+        node_metrics = {
+            "items": [
+                {
+                    "metadata": {"name": "edge-node"},
+                    "usage": {"memory": "2Gi", "cpu": "1000m"},
+                }
+            ]
+        }
+
+        with patch("app.metrics.resource_metrics.client.CustomObjectsApi") as custom_api:
+            custom_api.return_value.list_cluster_custom_object.return_value = node_metrics
+            result = _get_node_resources(v1)
+
+        assert result["ram"]["total"] == 4 * 1024**3
+        assert result["ram"]["used"] == 2 * 1024**3
+        assert result["cpu"] == {"utilization_pct": 25.0}
 
 
 class TestFindInferencePods:
@@ -235,31 +312,40 @@ class TestAttributeDetectorResources:
         """An active pod's RAM/VRAM lands in its detector's primary or oodd slot, and total_bytes sums both."""
         primary = _make_inference_pod("primary-pod")
         oodd = _make_inference_pod("oodd-pod", is_oodd=True)
-        detectors, loading_vram, loading_ram = _attribute_detector_resources(
+        detectors, loading_vram, loading_ram, loading_gpu_compute, loading_gpu_memory = _attribute_detector_resources(
             inference_pods=[(primary, DET_A, False, True), (oodd, DET_A, True, True)],
             active_pods={"primary-pod", "oodd-pod"},
             gpu_responses={
-                "primary-pod": {"pod": {"vram_bytes": 100}},
-                "oodd-pod": {"pod": {"vram_bytes": 50}},
+                "primary-pod": _gpu_process(100, compute_pct=10, memory_bw_pct=8),
+                "oodd-pod": _gpu_process(50, compute_pct=5, memory_bw_pct=3),
             },
             ram_by_pod={"primary-pod": 1000, "oodd-pod": 500},
         )
 
         assert loading_vram == 0 and loading_ram == 0
+        assert loading_gpu_compute == 0.0 and loading_gpu_memory == 0.0
         assert len(detectors) == 1
         det = detectors[0]
         assert det["detector_id"] == DET_A
         assert det["vram"] == {"primary_bytes": 100, "oodd_bytes": 50, "total_bytes": 150}
         assert det["ram"] == {"primary_bytes": 1000, "oodd_bytes": 500, "total_bytes": 1500}
+        assert det["gpu"] == {
+            "primary_compute_utilization_pct": 10.0,
+            "oodd_compute_utilization_pct": 5.0,
+            "total_compute_utilization_pct": 15.0,
+            "primary_memory_bandwidth_pct": 8.0,
+            "oodd_memory_bandwidth_pct": 3.0,
+            "total_memory_bandwidth_pct": 11.0,
+        }
 
     def test_only_primary_leaves_oodd_slot_none(self):
         """A detector with only a primary pod has oodd_bytes=None and total_bytes equal to primary."""
         primary = _make_inference_pod("primary-pod")
         inference_pods = [(primary, DET_A, False, True)]
-        detectors, _, _ = _attribute_detector_resources(
+        detectors, _, _, _, _ = _attribute_detector_resources(
             inference_pods,
             active_pods={"primary-pod"},
-            gpu_responses={"primary-pod": {"pod": {"vram_bytes": 100}}},
+            gpu_responses={"primary-pod": _gpu_process(100)},
             ram_by_pod={"primary-pod": 1000},
         )
         assert detectors[0]["vram"] == {"primary_bytes": 100, "oodd_bytes": None, "total_bytes": 100}
@@ -270,10 +356,10 @@ class TestAttributeDetectorResources:
         a = _make_inference_pod("a")
         b = _make_inference_pod("b")
         inference_pods = [(a, DET_A, False, True), (b, DET_B, False, True)]
-        detectors, _, _ = _attribute_detector_resources(
+        detectors, _, _, _, _ = _attribute_detector_resources(
             inference_pods,
             active_pods={"a", "b"},
-            gpu_responses={"a": {"pod": {"vram_bytes": 100}}, "b": {"pod": {"vram_bytes": 200}}},
+            gpu_responses={"a": _gpu_process(100), "b": _gpu_process(200)},
             ram_by_pod={"a": 1000, "b": 2000},
         )
         by_id = {d["detector_id"]: d for d in detectors}
@@ -285,17 +371,18 @@ class TestAttributeDetectorResources:
         """A non-active pod's RAM/VRAM rolls into the loading totals, not into a detector slot."""
         active_pod = _make_inference_pod("active")
         loading_pod = _make_inference_pod("loading")
-        detectors, loading_vram, loading_ram = _attribute_detector_resources(
+        detectors, loading_vram, loading_ram, loading_gpu_compute, loading_gpu_memory = _attribute_detector_resources(
             inference_pods=[(active_pod, DET_A, False, True), (loading_pod, DET_A, False, False)],
             active_pods={"active"},
             gpu_responses={
-                "active": {"pod": {"vram_bytes": 100}},
-                "loading": {"pod": {"vram_bytes": 800}},
+                "active": _gpu_process(100),
+                "loading": _gpu_process(800, compute_pct=30, memory_bw_pct=12),
             },
             ram_by_pod={"active": 1000, "loading": 5000},
         )
 
         assert loading_vram == 800 and loading_ram == 5000
+        assert loading_gpu_compute == 30.0 and loading_gpu_memory == 12.0
         assert len(detectors) == 1
         assert detectors[0]["vram"]["primary_bytes"] == 100
         assert detectors[0]["ram"]["primary_bytes"] == 1000
@@ -303,7 +390,7 @@ class TestAttributeDetectorResources:
     def test_missing_gpu_data_yields_zero_vram(self):
         """A pod with no GPU response contributes 0 VRAM but still picks up RAM from Metrics Server."""
         pod = _make_inference_pod("p")
-        detectors, _, _ = _attribute_detector_resources(
+        detectors, _, _, _, _ = _attribute_detector_resources(
             inference_pods=[(pod, DET_A, False, True)],
             active_pods={"p"},
             gpu_responses={},
@@ -316,29 +403,33 @@ class TestAttributeDetectorResources:
 class TestBuildGpuSummary:
     def test_single_pod_single_gpu(self):
         """Happy path: one pod, one device, totals match the device."""
-        responses = {"pod-a": {"gpus": [_gpu_device(used=200)]}}
-        observed, total, used = _build_gpu_summary(responses)
+        responses = {"pod-a": {"devices": [_gpu_device(used=200, compute_pct=20, memory_bw_pct=10)]}}
+        observed, devices, total, used, compute_pct, memory_bw_pct = _build_gpu_summary(responses)
         assert total == 1000 and used == 200
         assert observed == [{"name": "NVIDIA A10", "index": 0, "used_bytes": 200, "total_bytes": 1000}]
+        assert devices[0]["vram_used_bytes"] == 200
+        assert compute_pct == 20.0 and memory_bw_pct == 10.0
 
     def test_two_pods_same_gpu_dedupes_by_uuid(self):
         """Two pods reporting the same GPU (by uuid) must NOT double-count totals."""
         responses = {
-            "pod-a": {"gpus": [_gpu_device(used=200, uuid="GPU-shared")]},
-            "pod-b": {"gpus": [_gpu_device(used=300, uuid="GPU-shared")]},
+            "pod-a": {"devices": [_gpu_device(used=200, uuid="GPU-shared", compute_pct=20)]},
+            "pod-b": {"devices": [_gpu_device(used=300, uuid="GPU-shared", compute_pct=30)]},
         }
-        observed, total, used = _build_gpu_summary(responses)
+        observed, devices, total, used, compute_pct, _ = _build_gpu_summary(responses)
         assert total == 1000 and used == 300
         assert len(observed) == 1
         assert observed[0]["used_bytes"] == 300
+        assert devices[0]["compute_utilization_pct"] == 30.0
+        assert compute_pct == 30.0
 
     def test_dedupe_falls_back_to_name_index_when_uuid_missing(self):
         """When uuid is absent, the (name, index) pair is used as the dedupe key."""
         responses = {
-            "pod-a": {"gpus": [_gpu_device(used=200, uuid=None)]},
-            "pod-b": {"gpus": [_gpu_device(used=300, uuid=None)]},
+            "pod-a": {"devices": [_gpu_device(used=200, uuid=None)]},
+            "pod-b": {"devices": [_gpu_device(used=300, uuid=None)]},
         }
-        observed, total, used = _build_gpu_summary(responses)
+        observed, _, total, used, _, _ = _build_gpu_summary(responses)
         assert total == 1000 and used == 300
         assert len(observed) == 1
 
@@ -346,23 +437,25 @@ class TestBuildGpuSummary:
         """Different GPUs (different uuids) are kept separate and sorted by index."""
         responses = {
             "pod-a": {
-                "gpus": [
-                    _gpu_device(name="GPU-1", index=1, total=1000, used=100, uuid="uuid-1"),
-                    _gpu_device(name="GPU-0", index=0, total=2000, used=200, uuid="uuid-0"),
+                "devices": [
+                    _gpu_device(name="GPU-1", index=1, total=1000, used=100, uuid="uuid-1", compute_pct=20),
+                    _gpu_device(name="GPU-0", index=0, total=2000, used=200, uuid="uuid-0", compute_pct=40),
                 ]
             }
         }
-        observed, total, used = _build_gpu_summary(responses)
+        observed, devices, total, used, compute_pct, _ = _build_gpu_summary(responses)
         assert [g["index"] for g in observed] == [0, 1]
+        assert [g["index"] for g in devices] == [0, 1]
         assert total == 3000 and used == 300
+        assert compute_pct == 30.0
 
     def test_none_response_is_skipped(self):
-        """A pod whose /gpu-usage call failed (None response) is skipped without affecting totals."""
+        """A pod whose /v2/gpu-usage call failed (None response) is skipped without affecting totals."""
         responses = {
             "pod-down": None,
-            "pod-up": {"gpus": [_gpu_device(used=200)]},
+            "pod-up": {"devices": [_gpu_device(used=200)]},
         }
-        observed, total, used = _build_gpu_summary(responses)
+        observed, _, total, used, _, _ = _build_gpu_summary(responses)
         assert total == 1000 and used == 200
         assert len(observed) == 1
 
@@ -373,12 +466,12 @@ class TestBuildGpuSummary:
         """
         responses = {
             "pod-a": {
-                "gpus": [
+                "devices": [
                     _gpu_device(name=None, total=500, used=50, uuid=None),
                     _gpu_device(name="NVIDIA A10", index=0, total=1000, used=200, uuid="uuid-0"),
                 ]
             }
         }
-        observed, total, used = _build_gpu_summary(responses)
+        observed, _, total, used, _, _ = _build_gpu_summary(responses)
         assert [g["name"] for g in observed] == ["NVIDIA A10"]
         assert total == 1500 and used == 250

--- a/test/metrics/test_resource_metrics.py
+++ b/test/metrics/test_resource_metrics.py
@@ -419,9 +419,8 @@ class TestBuildGpuSummary:
     def test_single_pod_single_gpu(self):
         """Happy path: one pod, one device, totals match the device."""
         responses = {"pod-a": {"devices": [_gpu_device(used=200, compute_pct=20, memory_bw_pct=10)]}}
-        observed, devices, total, used, compute_pct, memory_bw_pct = _build_gpu_summary(responses)
+        devices, total, used, compute_pct, memory_bw_pct = _build_gpu_summary(responses)
         assert total == 1000 and used == 200
-        assert observed == [{"name": "NVIDIA A10", "index": 0, "used_bytes": 200, "total_bytes": 1000}]
         assert devices[0]["vram_bytes"]["used"] == 200
         assert compute_pct == 20.0 and memory_bw_pct == 10.0
 
@@ -431,10 +430,10 @@ class TestBuildGpuSummary:
             "pod-a": {"devices": [_gpu_device(used=200, uuid="GPU-shared", compute_pct=20)]},
             "pod-b": {"devices": [_gpu_device(used=300, uuid="GPU-shared", compute_pct=30)]},
         }
-        observed, devices, total, used, compute_pct, _ = _build_gpu_summary(responses)
+        devices, total, used, compute_pct, _ = _build_gpu_summary(responses)
         assert total == 1000 and used == 300
-        assert len(observed) == 1
-        assert observed[0]["used_bytes"] == 300
+        assert len(devices) == 1
+        assert devices[0]["vram_bytes"]["used"] == 300
         assert devices[0]["compute_utilization_pct"] == 30.0
         assert compute_pct == 30.0
 
@@ -444,9 +443,9 @@ class TestBuildGpuSummary:
             "pod-a": {"devices": [_gpu_device(used=200, uuid=None)]},
             "pod-b": {"devices": [_gpu_device(used=300, uuid=None)]},
         }
-        observed, _, total, used, _, _ = _build_gpu_summary(responses)
+        devices, total, used, _, _ = _build_gpu_summary(responses)
         assert total == 1000 and used == 300
-        assert len(observed) == 1
+        assert len(devices) == 1
 
     def test_multiple_distinct_gpus_sorted_by_index(self):
         """Different GPUs (different uuids) are kept separate and sorted by index."""
@@ -458,8 +457,7 @@ class TestBuildGpuSummary:
                 ]
             }
         }
-        observed, devices, total, used, compute_pct, _ = _build_gpu_summary(responses)
-        assert [g["index"] for g in observed] == [0, 1]
+        devices, total, used, compute_pct, _ = _build_gpu_summary(responses)
         assert [g["index"] for g in devices] == [0, 1]
         assert total == 3000 and used == 300
         assert compute_pct == 30.0
@@ -470,12 +468,12 @@ class TestBuildGpuSummary:
             "pod-down": None,
             "pod-up": {"devices": [_gpu_device(used=200)]},
         }
-        observed, _, total, used, _, _ = _build_gpu_summary(responses)
+        devices, total, used, _, _ = _build_gpu_summary(responses)
         assert total == 1000 and used == 200
-        assert len(observed) == 1
+        assert len(devices) == 1
 
     def test_unnamed_device_excluded_from_observed_but_still_counted_in_totals(self):
-        """A device with no `name` is dropped from observed_gpus but its bytes still flow into pod totals.
+        """A device with no `name` is dropped from devices but its bytes still flow into pod totals.
 
         Pinning current behavior so a future refactor doesn't silently change it.
         """
@@ -487,6 +485,6 @@ class TestBuildGpuSummary:
                 ]
             }
         }
-        observed, _, total, used, _, _ = _build_gpu_summary(responses)
-        assert [g["name"] for g in observed] == ["NVIDIA A10"]
+        devices, total, used, _, _ = _build_gpu_summary(responses)
+        assert [g["name"] for g in devices] == ["NVIDIA A10"]
         assert total == 1500 and used == 250


### PR DESCRIPTION
## Summary

- Restructure `/status/resources.json` so CPU, RAM, and GPU metrics have explicit units and consistent attribution buckets.
- Poll inference pods via `/v2/gpu-usage`, placing VRAM under `gpu.vram_bytes` alongside GPU compute and memory-bandwidth utilization.
- Update the bundled status page, dev mock server, and resource metric tests for the breaking response shape.

## Response Structure Diff

```diff
 {
   "system": {
-    "ram": {
-      "used_bytes": 123,
-      "total_bytes": 456,
-      "loading_detectors_bytes": 0,
-      "edge_endpoint_bytes": 0,
-      "eviction_threshold_pct": 75
+    "cpu_utilization_pct": {
+      "total": 4.96,
+      "detectors": 2.1,
+      "loading_detectors": 0.0,
+      "edge_endpoint": 0.8,
+      "other": 2.06
     },
-    "vram": {
-      "used_bytes": 123,
-      "total_bytes": 456,
-      "loading_detectors_bytes": 0,
-      "edge_endpoint_bytes": 0,
-      "observed_gpus": [...]
+    "ram_bytes": {
+      "total": 16455819264,
+      "used": 10862436352,
+      "detectors": 4932083712,
+      "loading_detectors": 0,
+      "edge_endpoint": 1003692032,
+      "other": 4926660608,
+      "eviction_threshold_pct": 75
+    },
+    "gpu": {
+      "vram_bytes": {
+        "total": 16106127360,
+        "used": 2824011776,
+        "detectors": 2353004544,
+        "loading_detectors": 0,
+        "edge_endpoint": 0,
+        "other": 471007232
+      },
+      "compute_utilization_pct": {
+        "total": 0.0,
+        "detectors": 0.0,
+        "loading_detectors": 0.0,
+        "edge_endpoint": 0.0,
+        "other": 0.0
+      },
+      "memory_bandwidth_pct": {
+        "total": 0.0,
+        "detectors": 0.0,
+        "loading_detectors": 0.0,
+        "edge_endpoint": 0.0,
+        "other": 0.0
+      },
+      "devices": [
+        {
+          "index": 0,
+          "uuid": "GPU-...",
+          "name": "Tesla T4",
+          "vram_bytes": {
+            "total": 16106127360,
+            "used": 2824011776,
+            "free": 13282115584
+          },
+          "compute_utilization_pct": 0.0,
+          "memory_bandwidth_pct": 0.0
+        }
+      ]
     }
   },
   "detectors": [
     {
       "detector_id": "det_...",
-      "ram": { "primary_bytes": 1, "oodd_bytes": 2, "total_bytes": 3 },
-      "vram": { "primary_bytes": 1, "oodd_bytes": 2, "total_bytes": 3 }
+      "cpu_utilization_pct": { "primary": 1.0, "oodd": 0.8, "total": 1.8 },
+      "ram_bytes": { "primary": 1, "oodd": 2, "total": 3 },
+      "gpu": {
+        "vram_bytes": { "primary": 1, "oodd": 2, "total": 3 },
+        "compute_utilization_pct": { "primary": 0.0, "oodd": 0.0, "total": 0.0 },
+        "memory_bandwidth_pct": { "primary": 0.0, "oodd": 0.0, "total": 0.0 }
+      }
     }
   ]
 }
```