### PR TITLE
Enable compilation and prevent benchmarking cache hits

### DIFF
--- a/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
@@ -73,6 +73,8 @@ spec:
           value: "{{ .Values.inferenceFlavor }}"
         - name: WORKERS  # Number of uvicorn workers for the inference server
           value: "1"
+        - name: EDGE_COMPILE_ENABLED
+          value: "{{ .Values.edgeCompileEnabled }}"
         volumeMounts:
         - name: edge-endpoint-persistent-volume
           mountPath: *modelRepository

--- a/deploy/helm/groundlight-edge-endpoint/values.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/values.yaml
@@ -57,6 +57,9 @@ persistentVolumeNameBase: "edge-endpoint-pv"
 # set this value to "cpu".
 inferenceFlavor: "gpu"
 
+# Whether to enable torch.compile (or equivalent) optimization in the inference server.
+edgeCompileEnabled: false
+
 # The user must provide the Groundlight API token as input or the deployment will fail
 groundlightApiToken: ""
 

--- a/load-testing/image_helpers.py
+++ b/load-testing/image_helpers.py
@@ -106,7 +106,7 @@ def generate_random_binary_image(
         text_color = BLACK
         label = "NO"
 
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
     cv2.putText(image, timestamp, (50, 100), cv2.FONT_HERSHEY_SIMPLEX, 1, text_color, 2)
 
     return image, label, None

--- a/load-testing/image_helpers.py
+++ b/load-testing/image_helpers.py
@@ -107,7 +107,13 @@ def generate_random_binary_image(
         label = "NO"
 
     timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
-    cv2.putText(image, timestamp, (50, 100), cv2.FONT_HERSHEY_SIMPLEX, 1, text_color, 2)
+    font = cv2.FONT_HERSHEY_SIMPLEX
+    # Scale relative to the 640x480 baseline so text occupies the same fraction of any image size.
+    font_scale = min(image_width / 640.0, image_height / 480.0)
+    thickness = max(1, round(font_scale * 2))
+    (_, text_h), _ = cv2.getTextSize(timestamp, font, font_scale, thickness)
+    margin = max(5, round(image_height * 0.02))
+    cv2.putText(image, timestamp, (margin, margin + text_h), font, font_scale, text_color, thickness)
 
     return image, label, None
 


### PR DESCRIPTION
  - Adds `edgeCompileEnabled` Helm value (default false) that sets `EDGE_COMPILE_ENABLED` on inference pods, allowing `torch.compile` to be toggled per deployment without modifying the chart.
  - Bumps the load-testing binary image generator's timestamp overlay from second resolution (%Y-%m-%d %H:%M:%S) to millisecond resolution (%H:%M:%S.%f truncated). Previously, all queries within the same wall-clock second produced
  byte-identical images, which collapsed to a single cache key in generic-cached-* pipelines and hid the encoder workload behind the feature cache.