### PR TITLE
Source load-test system utilization from /status/resources.json

### DIFF
--- a/load-testing/README.md
+++ b/load-testing/README.md
@@ -52,7 +52,12 @@ If `--edge-pipeline-config` is omitted, the detector's current/default edge pipe
 ### Multiple Client Throughput Test
 
 #### Purpose
-Tests the Edge Endpoint's ability to handle concurrent client load by spawning multiple client processes that ramp up gradually from 1 to N workers, measuring throughput and latency over time. During the test, host system utilization (CPU/GPU/RAM/VRAM) is also sampled and included in the generated artifacts.
+Tests the Edge Endpoint's ability to handle concurrent client load by spawning multiple client processes that ramp up gradually from 1 to N workers, measuring throughput and latency over time. During the test, system utilization (CPU/GPU/RAM/VRAM) is sampled by polling the Edge Endpoint's `/status/resources.json` and included in the generated artifacts.
+
+#### System utilization sampling
+Sampling cadence is controlled by `--system-sample-interval-seconds` (default 5s). Two notes:
+* Only system-level totals (`system.cpu_utilization_pct.total`, `system.ram_bytes`, `system.gpu.compute_utilization_pct.total`, `system.gpu.vram_bytes`) are recorded. Per-detector / `loading_detectors` / `other` buckets are intentionally ignored.
+* GPU/VRAM is fresh-on-call (~1s NVML ring buffer). CPU/RAM is bounded by the Kubernetes Metrics Server cadence (~15s default refresh). Adjacent samples will show GPU swinging while CPU/RAM stays flat — that is expected, not a bug.
 
 #### Usage
 ```

--- a/load-testing/groundlight_helpers.py
+++ b/load-testing/groundlight_helpers.py
@@ -46,14 +46,14 @@ class APIError(Exception):
     """
     pass
 
-def call_api(url: str, params: dict) -> dict:
+def call_api(url: str, params: dict, timeout: float | None = None) -> dict:
     """Perform a GET request with API token and return decoded JSON or raise APIError."""
 
     headers = {
         "X-API-Token": os.environ.get('GROUNDLIGHT_API_TOKEN')
     }
-    
-    response = requests.get(url, params=params, headers=headers)
+
+    response = requests.get(url, params=params, headers=headers, timeout=timeout)
     if response.status_code == 200:
         response_content = response.content.decode('utf-8')
         return json.loads(response_content)
@@ -130,6 +130,12 @@ def _get_status_metrics(gl: ExperimentalApi) -> dict:
     base = gl.endpoint.replace('/device-api', '')
     url = base + '/status/metrics.json'
     return call_api(url, {})
+
+def _get_resources(gl: ExperimentalApi, timeout: float = 5.0) -> dict:
+    """Retrieve the resource utilization JSON from the Edge Endpoint's /status/resources.json."""
+    base = gl.endpoint.replace('/device-api', '')
+    url = base + '/status/resources.json'
+    return call_api(url, {}, timeout=timeout)
 
 def get_container_images_map(gl: ExperimentalApi) -> dict[str, dict[str, str]]:
     """Return a map of pod -> {container: image_id} from edge status metrics."""

--- a/load-testing/multiple_client_throughput_test.py
+++ b/load-testing/multiple_client_throughput_test.py
@@ -204,6 +204,7 @@ def main(  # noqa: PLR0913
     image_height: int = 480,
     edge_pipeline_config: str | None = None,
     n: int | None = None,
+    system_sample_interval_seconds: float = 5.0,
 ) -> None:
     """Provision a detector for the requested mode and run the multi-client throughput ramp."""
     edge_pipeline_config = glh.normalize_edge_pipeline_config(edge_pipeline_config)
@@ -229,7 +230,7 @@ def main(  # noqa: PLR0913
     detectors = [detector.id]
     print(f"Running load test for {len(detectors)} detector(s).")
 
-    system_monitor = SystemMonitor(log_file)
+    system_monitor = SystemMonitor(log_file, sample_interval=system_sample_interval_seconds)
     system_monitor.start()
     try:
         incremental_client_ramp_up(
@@ -265,7 +266,7 @@ def main(  # noqa: PLR0913
         detector_mode=detector_mode, max_clients=max_clients, step_size=step_size,
         time_between_ramp=time_between_ramp, requests_per_second=requests_per_second,
         image_width=image_width, image_height=image_height, edge_pipeline_config=edge_pipeline_config,
-        n=n,
+        n=n, system_sample_interval_seconds=system_sample_interval_seconds,
     )
     write_load_test_results_to_file(
         log_file,
@@ -303,5 +304,13 @@ if __name__ == "__main__":
     parser.add_argument("--image-width", type=int, default=640)
     parser.add_argument("--image-height", type=int, default=480)
     parser.add_argument("--edge-pipeline-config", type=str, default=None, help="Edge pipeline configuration name.")
+    parser.add_argument(
+        "--system-sample-interval-seconds", type=float, default=5.0,
+        help=(
+            "How often to poll the Edge Endpoint's /status/resources.json for system utilization. "
+            "CPU/RAM are bounded by Kubernetes Metrics Server cadence (~15s); values below 15s give "
+            "repeated CPU/RAM samples but fresher GPU/VRAM samples."
+        ),
+    )
     args = parser.parse_args()
     main(**vars(args))

--- a/load-testing/multiple_client_throughput_test.py
+++ b/load-testing/multiple_client_throughput_test.py
@@ -204,9 +204,15 @@ def main(  # noqa: PLR0913
     image_height: int = 480,
     edge_pipeline_config: str | None = None,
     n: int | None = None,
-    system_sample_interval_seconds: float = 5.0,
+    system_sample_interval_seconds: float = 1.0,
 ) -> None:
-    """Provision a detector for the requested mode and run the multi-client throughput ramp."""
+    """Provision a detector for the requested mode and run the multi-client throughput ramp.
+    
+    Note: system_sample_interval_seconds is set to 1.0 to get more frequent sample. This only works
+    for GPU and VRAM metrics as the Kubernetes Metrics Server for CPU and RAM is 15 seconds. We
+    should revisit this when we have a way to get CPU and RAM metrics not through the Kubernetes 
+    Metrics Server.
+    """
     edge_pipeline_config = glh.normalize_edge_pipeline_config(edge_pipeline_config)
 
     gl = ExperimentalApi()

--- a/load-testing/multiple_client_throughput_test.py
+++ b/load-testing/multiple_client_throughput_test.py
@@ -311,7 +311,7 @@ if __name__ == "__main__":
     parser.add_argument("--image-height", type=int, default=480)
     parser.add_argument("--edge-pipeline-config", type=str, default=None, help="Edge pipeline configuration name.")
     parser.add_argument(
-        "--system-sample-interval-seconds", type=float, default=5.0,
+        "--system-sample-interval-seconds", type=float, default=1.0,
         help=(
             "How often to poll the Edge Endpoint's /status/resources.json for system utilization. "
             "CPU/RAM are bounded by Kubernetes Metrics Server cadence (~15s); values below 15s give "

--- a/load-testing/pyproject.toml
+++ b/load-testing/pyproject.toml
@@ -4,11 +4,9 @@ version = "0.1.0"
 description = "Scripts for testing the performance of the Groundlight Edge Endpoint"
 requires-python = ">=3.13"
 dependencies = [
-    "gputil>=1.4.0",
     "groundlight>=0.26.0",
     "matplotlib>=3.10.6",
     "opencv-python>=4.12.0.88",
-    "psutil>=7.1.0",
     "pydantic>=2.11.9",
     "pyyaml>=6.0.3",
     "setuptools>=75.1.0",

--- a/load-testing/system_helpers.py
+++ b/load-testing/system_helpers.py
@@ -1,18 +1,32 @@
 import json
 import multiprocessing
 import os
+import sys
 import time
 from datetime import datetime
 from typing import Optional
 
-import psutil
-import GPUtil
+from groundlight import ExperimentalApi
+
+import groundlight_helpers as glh
+
+
+_ERROR_LOG_INTERVAL_SEC = 30.0
 
 
 class SystemMonitor:
-    """Monitors CPU and GPU utilization in a background process and logs results."""
+    """Polls the Edge Endpoint's /status/resources.json in a background process and logs results.
 
-    def __init__(self, log_file: str, sample_interval: float = 1.0):
+    Emits one `event: "cpu"` and one `event: "gpu"` JSONL record per tick, matching
+    the schema parse_load_test_logs.py consumes. Only system-level totals are recorded;
+    per-detector / loading_detectors / other buckets are intentionally ignored
+    (NVML windowing skew, container PID mismatch — see PR #394 review discussion).
+
+    CPU/RAM samples are bounded by Kubernetes Metrics Server cadence (~15s); GPU/VRAM
+    are fresh-on-call. Sampling below 15s gives repeated CPU/RAM but fresher GPU.
+    """
+
+    def __init__(self, log_file: str, sample_interval: float = 5.0):
         self.log_file = log_file
         self.sample_interval = sample_interval
         self._stop_event = multiprocessing.Event()
@@ -39,48 +53,65 @@ class SystemMonitor:
         self._process = None
 
     @staticmethod
-    def _monitor_loop(log_file: str, sample_interval: float, stop_event: multiprocessing.Event) -> None:
-        psutil.cpu_percent(interval=None)  # Prime cpu_percent measurement
+    def _monitor_loop(log_file: str, sample_interval: float, stop_event) -> None:
+        gl = ExperimentalApi()
+        last_error_log_ts = 0.0
+
         while not stop_event.is_set():
             loop_start = time.time()
             event_ts = time.time()
             timestamp = datetime.fromtimestamp(event_ts).strftime("%Y-%m-%d %H:%M:%S")
 
-            cpu_percent = psutil.cpu_percent(interval=None)
-            memory_percent = psutil.virtual_memory().percent
+            try:
+                resources = glh._get_resources(gl)
+            except Exception as exc:
+                now = time.time()
+                if now - last_error_log_ts > _ERROR_LOG_INTERVAL_SEC:
+                    print(
+                        f"[SystemMonitor] Failed to fetch /status/resources.json: {exc}",
+                        file=sys.stderr,
+                    )
+                    last_error_log_ts = now
+                elapsed = time.time() - loop_start
+                remaining = sample_interval - elapsed
+                if remaining > 0:
+                    stop_event.wait(remaining)
+                continue
+
+            system = resources.get("system", {})
+            cpu_total = system.get("cpu_utilization_pct", {}).get("total", 0.0)
+            ram = system.get("ram_bytes", {})
+            ram_total = ram.get("total", 0)
+            ram_used = ram.get("used", 0)
+            memory_percent = (ram_used / ram_total * 100) if ram_total else 0.0
+
+            gpu = system.get("gpu", {})
+            gpu_compute_total = gpu.get("compute_utilization_pct", {}).get("total", 0.0)
+            vram = gpu.get("vram_bytes", {})
+            vram_total = vram.get("total", 0)
+            vram_used = vram.get("used", 0)
+            vram_percent = (vram_used / vram_total * 100) if vram_total else 0.0
+
             SystemMonitor._append_log(
                 log_file,
                 {
                     "asctime": timestamp,
                     "ts": event_ts,
                     "event": "cpu",
-                    "cpu_percent": round(cpu_percent, 2),
+                    "cpu_percent": round(cpu_total, 2),
                     "memory_percent": round(memory_percent, 2),
                 },
             )
-
-            gpus = GPUtil.getGPUs()
-            gpu_utilizations = [gpu.load * 100 for gpu in gpus]
-            vram_utilizations = [gpu.memoryUtil * 100 for gpu in gpus]
-            average_gpu_utilization = sum(gpu_utilizations) / len(gpu_utilizations) if gpu_utilizations else 0.0
-            average_vram_utilization = sum(vram_utilizations) / len(vram_utilizations) if vram_utilizations else 0.0
-            gpu_payload = {
-                "asctime": timestamp,
-                "ts": event_ts,
-                "event": "gpu",
-                "gpu_utilization": round(average_gpu_utilization, 2),
-                "vram_utilization": round(average_vram_utilization, 2),
-                "gpus": [
-                    {
-                        "id": gpu.id,
-                        "name": gpu.name,
-                        "gpu_utilization": round(gpu.load * 100, 2),
-                        "memory_utilization": round(gpu.memoryUtil * 100, 2),
-                    }
-                    for gpu in gpus
-                ],
-            }
-            SystemMonitor._append_log(log_file, gpu_payload)
+            SystemMonitor._append_log(
+                log_file,
+                {
+                    "asctime": timestamp,
+                    "ts": event_ts,
+                    "event": "gpu",
+                    "gpu_utilization": round(gpu_compute_total, 2),
+                    "vram_utilization": round(vram_percent, 2),
+                },
+            )
 
             elapsed = time.time() - loop_start
             remaining = sample_interval - elapsed
@@ -91,4 +122,3 @@ class SystemMonitor:
     def _append_log(log_file: str, payload: dict) -> None:
         with open(log_file, "a", encoding="utf-8") as log:
             log.write(json.dumps(payload) + "\n")
-

--- a/load-testing/uv.lock
+++ b/load-testing/uv.lock
@@ -181,12 +181,6 @@ wheels = [
 ]
 
 [[package]]
-name = "gputil"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/0e/5c61eedde9f6c87713e89d794f01e378cfd9565847d4576fa627d758c554/GPUtil-1.4.0.tar.gz", hash = "sha256:099e52c65e512cdfa8c8763fca67f5a5c2afb63469602d5dcb4d296b3661efb9", size = 5545, upload-time = "2018-12-18T09:12:13.63Z" }
-
-[[package]]
 name = "groundlight"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -279,11 +273,9 @@ name = "load-testing"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "gputil" },
     { name = "groundlight" },
     { name = "matplotlib" },
     { name = "opencv-python" },
-    { name = "psutil" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "setuptools" },
@@ -292,11 +284,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gputil", specifier = ">=1.4.0" },
     { name = "groundlight", specifier = ">=0.26.0" },
     { name = "matplotlib", specifier = ">=3.10.6" },
     { name = "opencv-python", specifier = ">=4.12.0.88" },
-    { name = "psutil", specifier = ">=7.1.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "setuptools", specifier = ">=75.1.0" },
@@ -481,22 +471,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
     { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
     { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
-]
-
-[[package]]
-name = "psutil"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/31/4723d756b59344b643542936e37a31d1d3204bcdc42a7daa8ee9eb06fb50/psutil-7.1.0.tar.gz", hash = "sha256:655708b3c069387c8b77b072fc429a57d0e214221d01c0a772df7dfedcb3bcd2", size = 497660, upload-time = "2025-09-17T20:14:52.902Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/62/ce4051019ee20ce0ed74432dd73a5bb087a6704284a470bb8adff69a0932/psutil-7.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76168cef4397494250e9f4e73eb3752b146de1dd950040b29186d0cce1d5ca13", size = 245242, upload-time = "2025-09-17T20:14:56.126Z" },
-    { url = "https://files.pythonhosted.org/packages/38/61/f76959fba841bf5b61123fbf4b650886dc4094c6858008b5bf73d9057216/psutil-7.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:5d007560c8c372efdff9e4579c2846d71de737e4605f611437255e81efcca2c5", size = 246682, upload-time = "2025-09-17T20:14:58.25Z" },
-    { url = "https://files.pythonhosted.org/packages/88/7a/37c99d2e77ec30d63398ffa6a660450b8a62517cabe44b3e9bae97696e8d/psutil-7.1.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:22e4454970b32472ce7deaa45d045b34d3648ce478e26a04c7e858a0a6e75ff3", size = 287994, upload-time = "2025-09-17T20:14:59.901Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/de/04c8c61232f7244aa0a4b9a9fbd63a89d5aeaf94b2fc9d1d16e2faa5cbb0/psutil-7.1.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c70e113920d51e89f212dd7be06219a9b88014e63a4cec69b684c327bc474e3", size = 291163, upload-time = "2025-09-17T20:15:01.481Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/58/c4f976234bf6d4737bc8c02a81192f045c307b72cf39c9e5c5a2d78927f6/psutil-7.1.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d4a113425c037300de3ac8b331637293da9be9713855c4fc9d2d97436d7259d", size = 293625, upload-time = "2025-09-17T20:15:04.492Z" },
-    { url = "https://files.pythonhosted.org/packages/79/87/157c8e7959ec39ced1b11cc93c730c4fb7f9d408569a6c59dbd92ceb35db/psutil-7.1.0-cp37-abi3-win32.whl", hash = "sha256:09ad740870c8d219ed8daae0ad3b726d3bf9a028a198e7f3080f6a1888b99bca", size = 244812, upload-time = "2025-09-17T20:15:07.462Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e9/b44c4f697276a7a95b8e94d0e320a7bf7f3318521b23de69035540b39838/psutil-7.1.0-cp37-abi3-win_amd64.whl", hash = "sha256:57f5e987c36d3146c0dd2528cd42151cf96cd359b9d67cfff836995cc5df9a3d", size = 247965, upload-time = "2025-09-17T20:15:09.673Z" },
-    { url = "https://files.pythonhosted.org/packages/26/65/1070a6e3c036f39142c2820c4b52e9243246fcfc3f96239ac84472ba361e/psutil-7.1.0-cp37-abi3-win_arm64.whl", hash = "sha256:6937cb68133e7c97b6cc9649a570c9a18ba0efebed46d8c5dae4c07fa1b67a07", size = 244971, upload-time = "2025-09-17T20:15:12.262Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace `psutil` + `GPUtil` sampling in `SystemMonitor` with HTTP polling of the Edge Endpoint's `/status/resources.json` (added in #394). Sampling on the load-driver host is wrong when the driver runs on a different machine than the system under test.
- Only system-level totals (`cpu_utilization_pct.total`, `ram_bytes`, `gpu.compute_utilization_pct.total`, `gpu.vram_bytes`) are consumed. Per-detector / `loading_detectors` / `other` buckets are intentionally ignored — see [#394 review discussion](https://github.com/groundlight/edge-endpoint/pull/394#issuecomment-4382862153) for the per-process attribution caveats.
- Preserves the JSONL schema (`cpu_percent`, `memory_percent`, `gpu_utilization`, `vram_utilization`) so `parse_load_test_logs.py` and downstream plots are unchanged.
- New `--system-sample-interval-seconds` flag (default 5s) on `multiple_client_throughput_test.py`. CPU/RAM are bounded by Kubernetes Metrics Server cadence (~15s) so adjacent samples will repeat CPU/RAM while GPU swings — this is documented in the README.
- Drops `gputil` and `psutil` from `load-testing/pyproject.toml` (no other consumers in `load-testing/`); regenerated `uv.lock`.

## Implementation notes
- `_get_resources(gl)` mirrors the existing `_get_status_metrics(gl)` helper in `groundlight_helpers.py`. `call_api` gained an optional `timeout` kwarg (default `None` preserves existing behavior); `_get_resources` passes `timeout=5.0` so a slow/hung Edge Endpoint during a load test can't stall the monitor.
- The monitor process constructs its own `ExperimentalApi()` from the `GROUNDLIGHT_ENDPOINT` env var (matching the existing pattern in `send_image_requests`) — avoids pickling a client across the `multiprocessing.Process` boundary.
- Resource-fetch errors are caught, logged at most once every 30s, and the tick is skipped — the load test keeps running even if the Edge Endpoint is momentarily unhealthy.

## Test plan
- [x] Mock `glh._get_resources` and drive `_monitor_loop` for a few ticks; verify JSONL shape matches the existing parser expectations.
- [x] Run `multiple_client_throughput_test.py BINARY --max-clients 4 --time-between-ramp 30` against a live G4 Edge Endpoint built from this branch; confirm `load_test.log` contains `event: "cpu"` and `event: "gpu"` lines at ~5s cadence.
- [x] Re-run `parse_load_test_logs.py` and confirm `throughput_and_system_utilization_over_time.png` and `time_vs_latency.png` render unchanged.
- [x] Cross-check the GPU line against `nvtop` and CPU against `kubectl top node` (allowing for the ~15s Metrics Server window).
- [x] Tail nginx access log on the Edge Endpoint; confirm ~120 `/status/resources.json` requests over a 10-minute test at 5s cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)