### PR TITLE
Reap orphaned eeut-* CICD instances by tag (sweeper blind-spot fix)

### DIFF
--- a/.github/workflows/sweeper-eeut.yaml
+++ b/.github/workflows/sweeper-eeut.yaml
@@ -59,3 +59,14 @@ jobs:
         working-directory: cicd/pulumi
         run: |
           ./sweep-destroy-eeut-stacks.sh
+
+      - name: Reap orphaned EEUT instances
+        # Safety net: terminates eeut-* EC2 instances whose `expires-<epoch>` tag
+        # has passed, independent of Pulumi state. Catches instances that outlived
+        # their stack (e.g. a `pulumi up` cancelled mid-create), which the
+        # stack-based sweeper above is structurally blind to. Runs even if the
+        # stack sweep failed, since it shares no state with it.
+        if: always()
+        working-directory: cicd/pulumi
+        run: |
+          ./reap-orphaned-eeut-instances.sh

--- a/cicd/pulumi/reap-orphaned-eeut-instances.sh
+++ b/cicd/pulumi/reap-orphaned-eeut-instances.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Safety-net cleanup for orphaned EEUT (edge-endpoint-under-test) instances.
+#
+# WHY THIS EXISTS
+# ---------------
+# The G4-end-to-end CI job creates a Pulumi stack named
+#   ee-cicd-<github_run_id>-expires-<unix_epoch>
+# and a g4dn EC2 instance tagged
+#   Name=eeut-ee-cicd-<github_run_id>-expires-<unix_epoch>
+# meant to live ~60 minutes. Normally sweep-destroy-eeut-stacks.sh tears it down
+# after the embedded expiry by walking `pulumi stack ls`.
+#
+# But that sweeper is entirely Pulumi-stack-driven, and an instance can outlive
+# its stack:
+#   - `pulumi up` is interrupted (PR cancel-in-progress, or a hard failure) after
+#     AWS has launched the instance but before Pulumi checkpoints it into state.
+#   - The instance now exists in AWS but is NOT tracked by the stack.
+#   - When the sweeper later processes the expired stack, `pulumi stack output
+#     eeut_instance_id` is empty and `pulumi destroy` "succeeds" against empty
+#     state, so `pulumi stack rm` deletes the stack -- abandoning the live
+#     instance. From then on `pulumi stack ls` shows nothing, so the stack
+#     sweeper is permanently blind to it. (A changed Pulumi org/project/backend
+#     causes the same blind spot for very old stacks.)
+#
+# This reaper closes that gap: it works directly from the EC2 Name tag,
+# independent of Pulumi state, reading the expiry straight out of the tag. It is
+# a complement to -- not a replacement for -- the stack sweeper: the stack
+# sweeper still owns Pulumi stack lifecycle for tracked stacks; this owns the
+# AWS-side safety net for orphans. There is nothing to clean up on the Pulumi
+# side for these orphans, because by definition their stack is already gone.
+#
+# Set DRY_RUN=1 to log what would be terminated without terminating anything.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-west-2}"
+NOW=$(date +%s)
+DRY_RUN="${DRY_RUN:-0}"
+
+echo "Reaping orphaned eeut-* instances in ${REGION} (now=${NOW}, dry_run=${DRY_RUN})"
+
+# Find non-terminated instances named like an EEUT test box. Other instances
+# (gha-runner, dev boxes, EKS nodes, ...) don't match eeut-* and are never
+# touched. We additionally require an `expires-<epoch>` token below, so anything
+# without a parseable expiry is left alone as a second safeguard.
+INSTANCES_JSON=$(aws ec2 describe-instances \
+  --region "${REGION}" \
+  --filters \
+    "Name=tag:Name,Values=eeut-*" \
+    "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+  --query 'Reservations[].Instances[].{Id:InstanceId, Name:Tags[?Key==`Name`]|[0].Value, State:State.Name}' \
+  --output json)
+
+NUM=$(echo "${INSTANCES_JSON}" | jq 'length')
+echo "Found ${NUM} live eeut-* instance(s)"
+
+REAPED=0
+while IFS= read -r row; do
+  [ -z "${row}" ] && continue
+  ID=$(echo "${row}" | jq -r '.Id')
+  NAME=$(echo "${row}" | jq -r '.Name')
+  STATE=$(echo "${row}" | jq -r '.State')
+
+  # Pull the expiry epoch out of the name: ...-expires-<digits>
+  EXPIRES=$(echo "${NAME}" | grep -oE 'expires-[0-9]+' | grep -oE '[0-9]+' || true)
+  if [ -z "${EXPIRES}" ]; then
+    echo "  SKIP ${ID} (${NAME}): no expires-<epoch> in name"
+    continue
+  fi
+
+  if [ "${NOW}" -le "${EXPIRES}" ]; then
+    REMAIN=$(( (EXPIRES - NOW) / 60 ))
+    echo "  KEEP ${ID} (${NAME}): not expired yet (~${REMAIN} min remaining, state=${STATE})"
+    continue
+  fi
+
+  OVERDUE=$(( (NOW - EXPIRES) / 60 ))
+  echo "  EXPIRED ${ID} (${NAME}): ${OVERDUE} min past expiry (state=${STATE})"
+  if [ "${DRY_RUN}" = "1" ]; then
+    echo "    [dry-run] would terminate ${ID}"
+  else
+    if aws ec2 terminate-instances --region "${REGION}" --instance-ids "${ID}" >/dev/null; then
+      echo "    terminated ${ID}"
+    else
+      echo "    FAILED to terminate ${ID}"
+    fi
+  fi
+  REAPED=$(( REAPED + 1 ))
+done < <(echo "${INSTANCES_JSON}" | jq -c '.[]')
+
+echo "Reaper complete: ${REAPED} expired instance(s) processed"


### PR DESCRIPTION
## Problem

We're leaking CICD GPU instances. The `G4-end-to-end` job creates a Pulumi stack `ee-cicd-<run_id>-expires-<epoch>` and a `g4dn.xlarge` tagged `eeut-ee-cicd-<run_id>-expires-<epoch>`, meant to live ~60 min. Cleanup is done by `sweep-destroy-eeut-stacks.sh`, which walks **`pulumi stack ls` only**.

That's a structural blind spot: an instance can outlive its stack.

- `pulumi up` gets interrupted (PR `cancel-in-progress`, or a hard failure) **after** AWS launched the instance but **before** Pulumi checkpointed it into state.
- The instance now exists in AWS but isn't tracked by the stack.
- When the sweeper later hits the expired stack, `pulumi stack output eeut_instance_id` is empty and `pulumi destroy` "succeeds" against empty state, so `pulumi stack rm` deletes the stack — **abandoning a live instance** that no longer appears in `pulumi stack ls`.
- From then on the stack sweeper is permanently blind to it. (A changed Pulumi org/project/backend produces the same blind spot for very old stacks.)

**Observed:** 7 orphaned `eeut-ee-cicd-*` `g4dn.xlarge` instances *still running*, expiry timestamps from `2025-03-28` (431 days overdue) through `2026-05-27`, while every `sweeper-eeut` run reports `Found 0 total stacks`. ~$0.526/hr each ≈ **~$2,650/mo** wasted. The two `gha-runner` boxes are the persistent self-hosted runners and are expected to stay up.

## Fix

`reap-orphaned-eeut-instances.sh` — a safety net that works directly from the EC2 `Name` tag, independent of Pulumi state:

- Lists non-terminated instances matching `Name=eeut-*`.
- Reads the expiry straight out of the `expires-<epoch>` token in the tag.
- Terminates anything past expiry; **keeps** anything not yet expired; **skips** anything without a parseable `expires-<epoch>`.

Wired into `sweeper-eeut.yaml` as an `if: always()` step after the existing stack sweep, so it runs even when the stack sweep fails (the two share no state).

### Blast radius
- `gha-runner`, dev boxes, and EKS nodes don't match `eeut-*` and are never touched.
- A missing/garbled `expires-<epoch>` is skipped, not terminated.
- `DRY_RUN=1` logs decisions without terminating.

## Testing
- `bash -n` clean.
- Local `DRY_RUN=1` run against a live account (0 `eeut-*` present) executes end-to-end cleanly.
- Synthetic decision-logic test passes: past-expiry running → terminate; future-expiry → keep; past-expiry stopped → terminate; no-`expires` name → skip.

> Note: the **currently leaked 7 instances live in the CICD account and predate this change** (their stacks are gone), so the next scheduled `sweeper-eeut` run on `main` will reap them once this merges. They can also be terminated manually now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)