### PR TITLE
Pin crane to v0.21.5 and add k3s cgroup v2 shim for balena builds

### DIFF
--- a/deploy/balena-k3s/server/Dockerfile
+++ b/deploy/balena-k3s/server/Dockerfile
@@ -11,12 +11,14 @@
 FROM alpine:3.20 AS preloader
 ARG K3S_TAG="v1.28.8+k3s1"
 
-# Install crane for pulling container images without a Docker daemon
-# Detect architecture via uname -m since Balena's legacy builder doesn't set TARGETARCH
+# Install crane for pulling container images without a Docker daemon.
+# Detect architecture via uname -m since Balena's legacy builder doesn't set TARGETARCH.
+# Pinned to a known-working release; bump deliberately after testing the build.
+ARG CRANE_VERSION=v0.21.5
 RUN apk add --no-cache curl tar && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ]; then CRANE_ARCH="arm64"; else CRANE_ARCH="x86_64"; fi && \
-    curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz" | \
+    curl -sL "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz" | \
     tar -xzf - -C /usr/local/bin crane
 
 # Download k3s airgap images (contains coredns, metrics-server, local-path-provisioner, etc.)

--- a/deploy/balena-k3s/server/Dockerfile.gpu
+++ b/deploy/balena-k3s/server/Dockerfile.gpu
@@ -22,11 +22,13 @@
 FROM alpine:3.20 AS preloader
 ARG K3S_TAG="v1.28.8+k3s1"
 
-# Install crane for pulling container images without a Docker daemon
+# Install crane for pulling container images without a Docker daemon.
+# Pinned to a known-working release; bump deliberately after testing the build.
+ARG CRANE_VERSION=v0.21.5
 RUN apk add --no-cache curl tar && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ]; then CRANE_ARCH="arm64"; else CRANE_ARCH="x86_64"; fi && \
-    curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz" | \
+    curl -sL "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz" | \
     tar -xzf - -C /usr/local/bin crane
 
 # Download k3s airgap images (contains coredns, metrics-server, local-path-provisioner, etc.)

--- a/deploy/balena-k3s/server/Dockerfile.jetson
+++ b/deploy/balena-k3s/server/Dockerfile.jetson
@@ -12,12 +12,14 @@
 FROM alpine:3.20 AS preloader
 ARG K3S_TAG="v1.28.8+k3s1"
 
-# Install crane for pulling container images without a Docker daemon
-# Detect architecture via uname -m since Balena's legacy builder doesn't set TARGETARCH
+# Install crane for pulling container images without a Docker daemon.
+# Detect architecture via uname -m since Balena's legacy builder doesn't set TARGETARCH.
+# Pinned to a known-working release; bump deliberately after testing the build.
+ARG CRANE_VERSION=v0.21.5
 RUN apk add --no-cache curl tar && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ]; then CRANE_ARCH="arm64"; else CRANE_ARCH="x86_64"; fi && \
-    curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz" | \
+    curl -sL "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz" | \
     tar -xzf - -C /usr/local/bin crane
 
 # Download k3s airgap images (contains coredns, metrics-server, local-path-provisioner, etc.)

--- a/deploy/balena-k3s/server/server.sh
+++ b/deploy/balena-k3s/server/server.sh
@@ -12,6 +12,21 @@ set -eux
 # doesnt work well when the underlying storage is an sd card, like on raspberry pi.
 # If we ever do want multi-node we'd have to pass `--server` or `--cluster-init` args to k3s
 
+# cgroup v2 shim: on hosts using the unified cgroup hierarchy (balenaOS 7.x+),
+# the container is started in a private cgroup namespace whose root already
+# has controllers enabled in "domain" mode. kubelet then cannot create
+# /sys/fs/cgroup/kubepods as a controller cgroup ("cannot enter cgroupv2 ...
+# with domain controllers -- it is in an invalid state"), and k3s crash-loops.
+# Move PID 1 into a leaf cgroup and enable controllers in the root's
+# subtree_control so kubelet can create kubepods alongside it. No-op on
+# cgroup v1 hosts.
+if [ "$(stat -c %T -f /sys/fs/cgroup 2>/dev/null)" = "cgroup2fs" ]; then
+    mkdir -p /sys/fs/cgroup/init
+    echo 1 > /sys/fs/cgroup/init/cgroup.procs
+    sed -e "s/ / +/g" -e "s/^/+/" < /sys/fs/cgroup/cgroup.controllers \
+        > /sys/fs/cgroup/cgroup.subtree_control
+fi
+
 # Flush stale CNI portmap iptables rules left over from a previous K3s instance.
 # After a container restart (e.g. balena device purge), K3s starts fresh but old
 # CNI DNAT rules persist in the host kernel.  If a new pod gets a different IP


### PR DESCRIPTION
## Summary

Ports two fixes from the gep balena fleet — [axon-groundlight/gep#165](https://github.com/axon-groundlight/gep/pull/165) (crane pin) and [axon-groundlight/gep#166](https://github.com/axon-groundlight/gep/pull/166) (cgroup v2 shim) — to edge-endpoint's parallel `deploy/balena-k3s/` path. Both repos share the same k3s-server-in-a-balena-container architecture and crane-based image preloader (introduced here in #370), so both bugs the gep PRs fixed exist here verbatim.

## 1. Pin crane to v0.21.5 (all 3 server Dockerfiles)

`deploy/balena-k3s/server/{Dockerfile,Dockerfile.gpu,Dockerfile.jetson}` each fetched `crane` from `releases/latest` and then `crane pull docker.io/amazon/aws-cli:latest`. `releases/latest` now resolves to **v0.21.6** (published 2026-05-18), which has a regression where `crane pull` of large multi-arch images writes the full OCI archive and then **never exits** — the build hangs indefinitely with no error.

Because `releases/latest` is an unpinned redirect resolved at build time, this rolled in with no code change here. **Any `./deploy_balena.sh <fleet> {cpu,gpu,jetson}` run today hangs in the preloader stage**, for every flavor, regardless of the target device's OS — it's a build-time bug.

Fix: add `ARG CRANE_VERSION=v0.21.5` and pull from `releases/download/${CRANE_VERSION}/...`.

| crane version | `crane pull amazon/aws-cli:latest` |
| --- | --- |
| `v0.21.5` (2026-04-11) | exits 0 in ~30s |
| `v0.21.6` (2026-05-18) | sleeps forever; SIGKILL required |

## 2. Add k3s cgroup v2 shim (`server.sh`)

balenaOS 7.x switched the host to the unified cgroup v2 hierarchy. The k3s server container then starts in a private cgroup namespace whose root already has controllers enabled in "domain" mode, so kubelet cannot create `/sys/fs/cgroup/kubepods`:

```
cannot enter cgroupv2 "/sys/fs/cgroup/kubepods" with domain controllers -- it is in an invalid state
```

and k3s crash-loops. Balena's compose validator rejects `cgroup: host`, so the host-side fix is unavailable. Apply the standard in-container workaround (same one moby/k3s use): move PID 1 into a leaf cgroup and enable controllers in the root's `subtree_control` so kubelet can create `kubepods` alongside `/init`.

Gated on `cgroup2fs` detection, so it is a **no-op on the cgroup v1 hosts (balenaOS 6.x)** currently in the field.

## Scope notes

- `deploy/bin/install-k3s.sh` (host-side k3s installer) is **not** affected: it runs k3s directly on the host cgroup namespace, so it never hits the private-namespace problem, and it already has its own cgroup-validation logic.
- gep maintains a single templated `Dockerfile.j2`; edge-endpoint hand-maintains three separate Dockerfiles, so the crane pin is applied to all three.

## Test plan

These mirror the gep changes, which were verified end-to-end on the `groundlight_prod/gep-release` fleet (balenaOS 7.0.5) per gep#165 / gep#166. For edge-endpoint specifically:

- [x] `./deploy_balena.sh <fleet> cpu` — preloader stage completes (no crane hang) and the build advances past image preloading.
- [x] `./deploy_balena.sh <fleet> gpu` and `jetson-orin` — same.
- [x] Deploy to a balenaOS 7.x device — `server` container starts k3s without the cgroupv2 crash-loop.
- [x] Confirm a balenaOS 6.x device still starts (shim is a no-op on cgroup v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
