### PR TITLE
Fix nginx cloud fallback for non-Cloudflare upstream endpoints

### DIFF
--- a/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
+++ b/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
@@ -56,8 +56,8 @@ http {
             proxy_set_header Connection "";
 
             # Ensure correct SNI/Host to upstream
-            proxy_ssl_server_name on;
-            proxy_ssl_name $upstreamHost;
+            proxy_ssl_server_name on;                 # send SNI
+            proxy_ssl_name $upstreamHost;             # hostname only, not full URL
             proxy_set_header Host $upstreamHost;
 
             # Forward standard headers

--- a/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
+++ b/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
@@ -48,14 +48,17 @@ http {
             resolver __NAME_SERVER__ valid=30s;
             {{- $parsedURL := .Values.upstreamEndpoint | urlParse }}
             set $upstreamEndpoint {{  index $parsedURL "scheme" }}://{{ index $parsedURL "host" }};
+            set $upstreamHost {{ index $parsedURL "host" }};
 
             # Fallback to the cloud API server
             proxy_pass $upstreamEndpoint;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
 
             # Ensure correct SNI/Host to upstream
-            proxy_ssl_server_name on;                 # send SNI
-            proxy_ssl_name $upstreamEndpoint;         # (explicit; optional if using $proxy_host)
-            proxy_set_header Host $proxy_host;        # or: proxy_set_header Host api.groundlight.ai;
+            proxy_ssl_server_name on;
+            proxy_ssl_name $upstreamHost;
+            proxy_set_header Host $upstreamHost;
 
             # Forward standard headers
             proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
The nginx `@fallback` block had two bugs that prevented cloud fallback from working when `upstreamEndpoint` points at a Fastly-backed host (e.g. `api.groundlight.dev.axon.com`), while silently working for Cloudflare-backed prod (`api.groundlight.ai`):

1. **Wrong SNI name:** `proxy_ssl_name` was set to `$proxy_host`, which when `proxy_pass` uses a variable resolves to the full URL including scheme (`https://api.groundlight.dev.axon.com`) instead of just the hostname. Fastly is strict about SNI and closes the connection; Cloudflare is not and accepts it anyway. Fixed by extracting `$upstreamHost` explicitly from the parsed URL at config time.

2. **HTTP/1.0 upstream connection:** nginx defaults to HTTP/1.0 for upstream proxy connections. Fastly requires HTTP/1.1. Added `proxy_http_version 1.1` and `proxy_set_header Connection ""` to the fallback block.
