### PR TITLE
Add GROUNDLIGHT_ENDPOINT into escalation-queue-reader container

### DIFF
--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -272,6 +272,8 @@ spec:
         env:
         - name: LOG_LEVEL
           value: {{ .Values.logLevel | quote }}
+        - name: GROUNDLIGHT_ENDPOINT
+          value: "{{ .Values.upstreamEndpoint }}"
         - name: GROUNDLIGHT_API_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The `escalation-queue-reader` container doesn't have the `GROUNDLIGHT_ENDPOINT` env var, so escalation fails if the Edge Endpoint is connected to a different upstream endpoint. This PR fixes that. I have tested it locally, and it works. 