### PR TITLE
Update Brandon's GitHub username in reviewer lottery

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -8,7 +8,7 @@ groups:
       - tomfaulhaber
       - roxanne-o
       - timmarkhuff
-      - brandon-groundlight
+      - brandon-wada
       - f-wright
       - CoreyEWood
       - honeytung


### PR DESCRIPTION
I noticed that some EE dependabot PRs weren't getting reviewers assigned. I think this incorrect username in the reviewer lottery is why.