### PR TITLE
Make status page detector links point to the connected environment's …

### DIFF
--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -361,6 +361,8 @@ class MockHandler(BaseHTTPRequestHandler):
                 data = build_metrics(state)
             elif self.path == "/edge-config":
                 data = build_edge_config(state)
+            elif self.path == "/status/config.json":
+                data = {"dashboard_url": "https://dashboard.groundlight.ai"}
             else:
                 self.send_error(404)
                 return

--- a/app/status_monitor/frontend/src/App.jsx
+++ b/app/status_monitor/frontend/src/App.jsx
@@ -24,6 +24,10 @@ import { DARK_HEADER_STYLE } from "./sharedStyles";
 // Faster polling in dev is helpful when iterating, slow down polling in prod
 const REFRESH_MS = import.meta.env.DEV ? 1_000 : 10_000;
 
+// Fallback dashboard for detector links until /status/config.json resolves (or
+// if it fails). The backend derives the real value from the upstream endpoint.
+const DEFAULT_DASHBOARD_URL = "https://dashboard.groundlight.ai";
+
 const parseIfJson = (value) => {
   if (typeof value === "string") {
     try {
@@ -220,6 +224,7 @@ export default function App() {
   const [resources, setResources] = useState(null);
   const [edgeConfig, setEdgeConfig] = useState(null);
   const [edgeConfigError, setEdgeConfigError] = useState(false);
+  const [dashboardUrl, setDashboardUrl] = useState(DEFAULT_DASHBOARD_URL);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const intervalRef = useRef(null);
@@ -258,6 +263,25 @@ export default function App() {
     } catch {
       setEdgeConfigError(true);
     }
+  }, []);
+
+  // The dashboard URL is static for the lifetime of the page, so fetch it once
+  // rather than on every poll. Keep the default on any failure.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/status/config.json");
+        if (!res.ok) return;
+        const cfg = await res.json();
+        if (!cancelled && cfg?.dashboard_url) setDashboardUrl(cfg.dashboard_url);
+      } catch {
+        // Keep the default dashboard URL.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -322,7 +346,7 @@ export default function App() {
 
         <Stack gap="xl">
           <CollapsibleSection title="Detector Details">
-            <DetectorDetails details={detectorDetails} loading={loading} />
+            <DetectorDetails details={detectorDetails} loading={loading} dashboardUrl={dashboardUrl} />
           </CollapsibleSection>
 
           <CollapsibleSection title="Resource Usage by Detector">

--- a/app/status_monitor/frontend/src/components/DetectorDetails.jsx
+++ b/app/status_monitor/frontend/src/components/DetectorDetails.jsx
@@ -197,7 +197,7 @@ function getTimestamp(info) {
   return Number.isNaN(t) ? Date.now() : t;
 }
 
-export default function DetectorDetails({ details, loading }) {
+export default function DetectorDetails({ details, loading, dashboardUrl = "https://dashboard.groundlight.ai" }) {
   // null = default sort by deployment creation time (oldest first)
   const [sortDir, setSortDir] = useState(null);
 
@@ -283,7 +283,7 @@ export default function DetectorDetails({ details, loading }) {
                 <Table.Td style={{ verticalAlign: "top", overflow: "hidden" }}>
                   <Stack gap={4}>
                     <Anchor
-                      href={`https://dashboard.groundlight.ai/reef/detectors/${id}`}
+                      href={`${dashboardUrl.replace(/\/$/, "")}/reef/detectors/${id}`}
                       target="_blank"
                       size="sm"
                       underline="always"

--- a/app/status_monitor/status_web.py
+++ b/app/status_monitor/status_web.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI
@@ -13,6 +14,38 @@ from app.metrics.resource_metrics import ResourceMetricsCollector
 
 ONE_HOUR_IN_SECONDS = 3600
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+
+# The production Groundlight dashboard. Used as a fallback when the upstream
+# endpoint is unset or doesn't follow the conventional api.<env>.groundlight.ai
+# naming (e.g. localhost, an IP address, or a custom hostname).
+DEFAULT_DASHBOARD_URL = "https://dashboard.groundlight.ai"
+
+
+def dashboard_base_url() -> str:
+    """Derive the Groundlight dashboard base URL from the upstream API endpoint.
+
+    The Edge Endpoint forwards to an upstream Groundlight service configured via
+    the GROUNDLIGHT_ENDPOINT env var. Each environment's API host is conventionally
+    named ``api.<env>.groundlight.ai`` (e.g. ``api.groundlight.ai`` for prod,
+    ``api.integ.groundlight.ai`` for integ) and its dashboard lives at the matching
+    ``dashboard.<env>.groundlight.ai``. We swap the leading ``api`` label for
+    ``dashboard`` so detector links on the status page open the dashboard for the
+    environment this endpoint is actually connected to, rather than always prod.
+
+    Falls back to the production dashboard for anything non-standard so links
+    remain functional.
+    """
+    endpoint = os.environ.get("GROUNDLIGHT_ENDPOINT", "").strip()
+    if not endpoint:
+        return DEFAULT_DASHBOARD_URL
+    parsed = urlparse(endpoint if "://" in endpoint else f"https://{endpoint}")
+    host = parsed.hostname or ""
+    labels = host.split(".")
+    if labels and labels[0] == "api":
+        labels[0] = "dashboard"
+        return f"{parsed.scheme}://{'.'.join(labels)}"
+    return DEFAULT_DASHBOARD_URL
+
 
 STATIC_DIR = Path(__file__).parent / "static"
 REACT_BUILD_DIR = Path(__file__).parent / "react-build"
@@ -50,6 +83,16 @@ async def get_metrics():
 def get_resources():
     """Return per-detector GPU and RAM usage as JSON."""
     return resource_collector.collect()
+
+
+@app.get("/status/config.json")
+def get_config():
+    """Return static frontend config, e.g. the dashboard URL for detector links.
+
+    Derived from the upstream endpoint so links open the correct environment's
+    dashboard (prod, integ, dev, etc.) instead of always pointing at prod.
+    """
+    return {"dashboard_url": dashboard_base_url()}
 
 
 @app.get("/status")

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -231,9 +231,6 @@ spec:
         env:
         - name: LOG_LEVEL
           value: {{ .Values.logLevel | quote }}
-        # Needed so the status page can derive the correct dashboard URL for
-        # detector links based on the upstream environment (prod, integ, dev, etc.)
-        # instead of always linking to prod.
         - name: GROUNDLIGHT_ENDPOINT
           value: "{{ .Values.upstreamEndpoint }}"
         - name: GROUNDLIGHT_API_TOKEN

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -231,6 +231,11 @@ spec:
         env:
         - name: LOG_LEVEL
           value: {{ .Values.logLevel | quote }}
+        # Needed so the status page can derive the correct dashboard URL for
+        # detector links based on the upstream environment (prod, integ, dev, etc.)
+        # instead of always linking to prod.
+        - name: GROUNDLIGHT_ENDPOINT
+          value: "{{ .Values.upstreamEndpoint }}"
         - name: GROUNDLIGHT_API_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
…dashboard

The "Groundlight Edge Endpoint Status" page hardcoded detector links to https://dashboard.groundlight.ai (prod). When the Edge Endpoint is connected to a non-prod upstream (integ, dev/ag1, etc.), clicking a detector ID opened the wrong dashboard and failed.

Derive the dashboard base URL from the upstream GROUNDLIGHT_ENDPOINT instead:
- Inject GROUNDLIGHT_ENDPOINT into the status-monitor container (it was the only core container missing it).
- Add a dashboard_base_url() helper + /status/config.json endpoint that maps api.<env>.groundlight.ai -> dashboard.<env>.groundlight.ai, falling back to the prod dashboard for non-standard endpoints (localhost, IPs, etc.).
- Fetch the URL once on the frontend and use it for detector links.
- Add the endpoint to the dev mock server.