### PR TITLE
Derive edge image registry from a single ecrRegistry value

### DIFF
--- a/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
@@ -48,7 +48,7 @@ spec:
 
       containers:
       - name: inference-server
-        image: 767397850842.dkr.ecr.us-west-2.amazonaws.com/gl-edge-inference{{ if .Values.useMinimalImage }}-minimal{{ end }}:{{ include "groundlight-edge-endpoint.inferenceTag" . }}
+        image: {{ .Values.ecrRegistry }}/gl-edge-inference{{ if .Values.useMinimalImage }}-minimal{{ end }}:{{ include "groundlight-edge-endpoint.inferenceTag" . }}
         imagePullPolicy: "{{ include "groundlight-edge-endpoint.inferencePullPolicy" . }}"
         env:
         - name: MODEL_REPOSITORY

--- a/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/files/inference-deployment-template.yaml
@@ -48,7 +48,7 @@ spec:
 
       containers:
       - name: inference-server
-        image: {{ .Values.ecrRegistry }}/gl-edge-inference{{ if .Values.useMinimalImage }}-minimal{{ end }}:{{ include "groundlight-edge-endpoint.inferenceTag" . }}
+        image: {{ include "groundlight-edge-endpoint.ecrRegistry" . }}/gl-edge-inference{{ if .Values.useMinimalImage }}-minimal{{ end }}:{{ include "groundlight-edge-endpoint.inferenceTag" . }}
         imagePullPolicy: "{{ include "groundlight-edge-endpoint.inferencePullPolicy" . }}"
         env:
         - name: MODEL_REPOSITORY

--- a/deploy/helm/groundlight-edge-endpoint/files/init-aws-access-apply.sh
+++ b/deploy/helm/groundlight-edge-endpoint/files/init-aws-access-apply.sh
@@ -37,7 +37,7 @@ kubectl create secret generic aws-credentials-file --from-file /shared/credentia
     --dry-run=client -o yaml | kubectl apply -f -
 
 kubectl create secret docker-registry registry-credentials \
-    --docker-server={{ .Values.ecrRegistry }} \
+    --docker-server={{ include "groundlight-edge-endpoint.ecrRegistryHost" . }} \
     --docker-username=AWS \
     --docker-password="$(cat /shared/token.txt)" \
     --dry-run=client -o yaml | kubectl apply -f -

--- a/deploy/helm/groundlight-edge-endpoint/templates/_helpers.tpl
+++ b/deploy/helm/groundlight-edge-endpoint/templates/_helpers.tpl
@@ -89,6 +89,35 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+  Resolve the edge image base (ECR registry host plus optional repo prefix) for the
+  configured upstreamEndpoint. Edge installs pass upstreamEndpoint as the single
+  "which environment" signal, so the registry is derived from it via
+  .Values.ecrRegistryMap rather than a separate argument. An explicit
+  .Values.ecrRegistry overrides the map; upstreams absent from the map fall back to
+  the prod (api.groundlight.ai) entry so existing self-hosted installs keep pulling
+  from GL_Public. The result is prepended to each image repo name, so it never ends
+  with a slash.
+*/}}
+{{- define "groundlight-edge-endpoint.ecrRegistry" -}}
+{{- if .Values.ecrRegistry -}}
+{{- .Values.ecrRegistry -}}
+{{- else -}}
+{{- $map := .Values.ecrRegistryMap -}}
+{{- $default := index $map "https://api.groundlight.ai" -}}
+{{- index $map .Values.upstreamEndpoint | default $default -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  The registry host portion of the resolved image base (everything before the first
+  "/"). Image pull secrets key on the registry host, so the registry-credentials
+  docker-server must use this rather than the full image base.
+*/}}
+{{- define "groundlight-edge-endpoint.ecrRegistryHost" -}}
+{{- include "groundlight-edge-endpoint.ecrRegistry" . | splitList "/" | first -}}
+{{- end -}}
+
+{{/*
   Determine the correct pull policy to use for each container type. If it is 
   a dev tag, we use "Never" to avoid pulling from the registry. Otherwise,
   we use the global pull policy.

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -61,7 +61,7 @@ spec:
       serviceAccountName: edge-endpoint-service-account
       initContainers:
       - name: generate-tls-cert
-        image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:{{ include "groundlight-edge-endpoint.edgeEndpointTag" . }}
+        image: &edgeEndpointImage {{ .Values.ecrRegistry }}/edge-endpoint:{{ include "groundlight-edge-endpoint.edgeEndpointTag" . }}
         imagePullPolicy: "{{ include "groundlight-edge-endpoint.edgeEndpointPullPolicy" . }}"
         volumeMounts:
         - name: nginx-certs

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -61,7 +61,7 @@ spec:
       serviceAccountName: edge-endpoint-service-account
       initContainers:
       - name: generate-tls-cert
-        image: &edgeEndpointImage {{ .Values.ecrRegistry }}/edge-endpoint:{{ include "groundlight-edge-endpoint.edgeEndpointTag" . }}
+        image: &edgeEndpointImage {{ include "groundlight-edge-endpoint.ecrRegistry" . }}/edge-endpoint:{{ include "groundlight-edge-endpoint.edgeEndpointTag" . }}
         imagePullPolicy: "{{ include "groundlight-edge-endpoint.edgeEndpointPullPolicy" . }}"
         volumeMounts:
         - name: nginx-certs

--- a/deploy/helm/groundlight-edge-endpoint/values.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/values.yaml
@@ -80,6 +80,12 @@ s3Mount:
   mountPath: "/opt/groundlight/edge/pinamod-mount"
   cachePath: "/opt/groundlight/edge/pinamod-cache"
 
+# Registry host for the edge-endpoint and inference-server images and for the
+# registry-credentials pull secret. Single source of truth for all three.
+# Defaults to the legacy GL_Public account. Edge artifacts are migrating to
+# dedicated per-environment Axon accounts; once those exist this should be derived
+# from upstreamEndpoint instead of hardcoded.
+# TODO: derive per environment from upstreamEndpoint when the dev/prod edge ECRs are live (see edge artifacts migration plan).
 ecrRegistry: "767397850842.dkr.ecr.us-west-2.amazonaws.com"
 
 # This sets the log level for all the containers, both edge endpoint and inference.

--- a/deploy/helm/groundlight-edge-endpoint/values.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/values.yaml
@@ -80,13 +80,27 @@ s3Mount:
   mountPath: "/opt/groundlight/edge/pinamod-mount"
   cachePath: "/opt/groundlight/edge/pinamod-cache"
 
-# Registry host for the edge-endpoint and inference-server images and for the
-# registry-credentials pull secret. Single source of truth for all three.
-# Defaults to the legacy GL_Public account. Edge artifacts are migrating to
-# dedicated per-environment Axon accounts; once those exist this should be derived
-# from upstreamEndpoint instead of hardcoded.
-# TODO: derive per environment from upstreamEndpoint when the dev/prod edge ECRs are live (see edge artifacts migration plan).
-ecrRegistry: "767397850842.dkr.ecr.us-west-2.amazonaws.com"
+# Edge image registry resolution.
+#
+# Edge installs already pass upstreamEndpoint as the single "which environment"
+# signal, so the ECR image base is derived from it via ecrRegistryMap rather than a
+# separate install argument. The resolved value is the registry host plus an optional
+# repo prefix, and is the single source of truth for all three image layers: the
+# edge-endpoint image, the inference image, and the docker-server of the
+# registry-credentials pull secret (which uses just the host portion of the base).
+#
+# Every entry currently points at the legacy GL_Public account, so behavior is
+# unchanged. When the dedicated Axon edge ECR accounts exist (aws-global #371), add
+# their entries here (host plus the `edge/` repo prefix, and jetson repo naming) and
+# the switch becomes a data-only change. Upstreams not in the map fall back to the
+# prod (api.groundlight.ai) entry, so existing self-hosted installs keep pulling from
+# GL_Public.
+ecrRegistryMap:
+  "https://api.groundlight.ai": "767397850842.dkr.ecr.us-west-2.amazonaws.com"
+
+# Explicit override / escape hatch for self-hosted or unmapped upstreams. When set,
+# it wins over ecrRegistryMap. Leave empty to derive from upstreamEndpoint.
+ecrRegistry: ""
 
 # This sets the log level for all the containers, both edge endpoint and inference.
 logLevel: "INFO"


### PR DESCRIPTION
## What

The `edge-endpoint` and inference-server images each hardcoded the GL_Public ECR host (`767397850842.dkr.ecr.us-west-2.amazonaws.com`), separate from the `ecrRegistry` value already used for the `registry-credentials` pull secret. This routes all three through a chart-local resolver keyed off `upstreamEndpoint` (the signal edge installs already provide), so no new install argument is added.

- `ecrRegistryMap` (`values.yaml`) maps `upstreamEndpoint` -> ECR image base (registry host + optional repo prefix)
- `ecrRegistry` helper -> full image base, used by the edge-endpoint and inference images
- `ecrRegistryHost` helper -> host portion only, used by the pull-secret `--docker-server` (which keys on the host, not the prefix)
- an explicit `ecrRegistry` value still overrides the map; upstreams absent from the map fall back to the prod (`api.groundlight.ai`) entry

## No behavior change

The only map entry points at the GL_Public host, so the default and the fallback both render byte-identical image strings. Verified the full chart renders cleanly and that the override and unmapped-upstream branches resolve as expected:

| Scenario | image base | docker-server host |
| --- | --- | --- |
| Default (`api.groundlight.ai`) | `767397850842.dkr.ecr.us-west-2.amazonaws.com` | same |
| Override `999.../edge` | `999.../edge` | `999...amazonaws.com` (prefix stripped) |
| Unmapped upstream | falls back to `767...` | same |

## Why

Establishes the registry-switching seam now so the move to the dedicated Axon edge ECR accounts (aws-global #371) is a data-only map edit: add the account host plus the `edge/` repo prefix (and jetson repo naming).