### PR TITLE
Serve status page edge-config under /status prefix

### DIFF
--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -359,7 +359,7 @@ class MockHandler(BaseHTTPRequestHandler):
                 data = build_resources(state)
             elif self.path == "/status/metrics.json":
                 data = build_metrics(state)
-            elif self.path == "/edge-config":
+            elif self.path == "/status/edge-config":
                 data = build_edge_config(state)
             else:
                 self.send_error(404)

--- a/app/status_monitor/frontend/src/App.jsx
+++ b/app/status_monitor/frontend/src/App.jsx
@@ -248,7 +248,7 @@ export default function App() {
     }
 
     try {
-      const res = await fetch("/edge-config");
+      const res = await fetch("/status/edge-config");
       if (res.ok) {
         setEdgeConfig(await res.json());
         setEdgeConfigError(false);

--- a/app/status_monitor/frontend/vite.config.js
+++ b/app/status_monitor/frontend/vite.config.js
@@ -19,7 +19,7 @@ export default defineConfig({
       "/status/resources.json": EDGE_ENDPOINT,
       "/status/static/icon_gold_dark.svg": EDGE_ENDPOINT,
       "/status/static/favicon.ico": EDGE_ENDPOINT,
-      "/edge-config": EDGE_ENDPOINT,
+      "/status/edge-config": EDGE_ENDPOINT,
     },
   },
 });

--- a/app/status_monitor/status_web.py
+++ b/app/status_monitor/status_web.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
+from app.core.edge_config_manager import EdgeConfigManager
 from app.metrics.iq_activity import clear_old_activity_files
 from app.metrics.metric_reporting import MetricsReporter
 from app.metrics.resource_metrics import ResourceMetricsCollector
@@ -50,6 +51,17 @@ async def get_metrics():
 def get_resources():
     """Return per-detector GPU and RAM usage as JSON."""
     return resource_collector.collect()
+
+
+@app.get("/status/edge-config")
+def get_edge_config():
+    """Return the active edge endpoint configuration as JSON.
+
+    Served here, under the /status prefix, so the status page can read it through the same
+    reverse proxy that fronts the rest of the status UI (e.g. the GEP hub). The main
+    edge-endpoint API also exposes /edge-config for SDK and tooling use.
+    """
+    return EdgeConfigManager.active().to_payload()
 
 
 @app.get("/status")


### PR DESCRIPTION
## Problem

In the GEP hub dashboard, the Edge Endpoint Status widget showed "Failed to load." in its Configuration section, with a `GET /edge-config 404 (Not Found)` in the browser console. The other widgets (metrics, resources) loaded fine.

The cause: the status page is one React app, but its fetches don't all go to the same place. `metrics.json` and `resources.json` live under `/status/` and are served by the status-monitor container, while `/edge-config` is served by the main edge-endpoint API container at the root path. GEP's reverse proxy only forwards and rewrites the `/status` prefix into the hub, so `/edge-config` never matches a route and 404s at the GEP layer. Standalone, edge-endpoint's own nginx fronts both containers, so it works there.

## Fix

Serve a read-only copy of the active config from the status-monitor at `/status/edge-config` and point the frontend at it, so it rides the same proxy path as the other status data. No GEP change is required.

- `status_web.py`: add `GET /status/edge-config` returning `EdgeConfigManager.active().to_payload()` (the status-monitor already mounts the active-config PVC).
- `App.jsx`: fetch `/status/edge-config` instead of `/edge-config`.
- `vite.config.js` and `dev/mock_server.py`: update the dev proxy and mock to the new path.

The main API's `/edge-config` GET/PUT is unchanged for SDK and tooling use.