### PR TITLE
Make hourly metrics reporting idempotent and durable

### DIFF
--- a/app/metrics/metric_reporting.py
+++ b/app/metrics/metric_reporting.py
@@ -6,8 +6,9 @@ Can also be run directly as a script.
 import json
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
+from pathlib import Path
 from typing import Any, Callable
 
 from groundlight import Groundlight
@@ -17,6 +18,17 @@ from app.escalation_queue import failed_escalations
 from app.metrics import iq_activity, system_metrics
 
 logger = logging.getLogger(__name__)
+
+# Directory where sealed hourly snapshots awaiting delivery to the cloud are persisted, alongside the
+# device-local activity counters. Persisting them (rather than only holding them in memory) means a
+# retry -- even across a process restart -- re-sends the *identical* sealed snapshot instead of
+# re-reading the live counters, which would produce a different total for the same (immutable) hour
+# and be permanently rejected by the cloud's unique (hour, device, detector) constraint.
+PENDING_REPORTS_DIR = Path("/opt/groundlight/device/edge-metrics/pending-cloud-reports")
+
+# Drop (stop retrying) a pending report once its hour is older than this. Late delivery is otherwise
+# fine -- the hour is immutable -- but this bounds disk growth if a report can never be delivered.
+PENDING_REPORT_MAX_AGE = timedelta(days=7)
 
 
 @lru_cache(maxsize=1)
@@ -49,10 +61,20 @@ class SafeMetricsDict:
 
 
 class MetricsReporter:
-    """Class that collects metrics and reports them to the cloud API."""
+    """Collects metrics and reports them to the cloud API.
 
-    def __init__(self):
-        self.metrics_to_send = {}
+    Hourly reporting is idempotent and durable. Each previous-hour snapshot is keyed by its
+    ``activity_hour`` (first-writer-wins) and persisted to disk, so a re-collection (e.g. a scheduler
+    misfire) or a retry after a process restart re-sends the exact same sealed snapshot rather than
+    re-reading the live counters. The cloud stores each (hour, device, detector) row immutably, so a
+    second, differently-valued snapshot for the same hour would be permanently rejected -- which is
+    the failure mode this is designed to avoid.
+    """
+
+    def __init__(self, pending_reports_dir: str | Path | None = None):
+        self.pending_reports_dir = Path(pending_reports_dir) if pending_reports_dir else PENDING_REPORTS_DIR
+        # Maps activity_hour -> sealed payload; mirrors the persisted snapshot files on disk.
+        self.metrics_to_send: dict[str, dict] = {}
 
     def metrics_payload(self) -> dict:
         """Returns a dictionary of metrics to be sent to the cloud API."""
@@ -94,18 +116,90 @@ class MetricsReporter:
             "k3s_stats": k3s_stats.as_dict(),
         }
 
+    def _report_path(self, key: str) -> Path:
+        """On-disk path for a queued snapshot. ``key`` is the activity_hour, e.g. '2026-06-24_15'."""
+        return self.pending_reports_dir / f"{key}.json"
+
+    def _persist_report(self, key: str, payload: dict) -> None:
+        """Atomically write a sealed snapshot to disk so it survives a process restart."""
+        try:
+            self.pending_reports_dir.mkdir(parents=True, exist_ok=True)
+            path = self._report_path(key)
+            tmp_path = path.with_name(f"{path.name}.tmp")
+            tmp_path.write_text(json.dumps(payload))
+            tmp_path.replace(path)  # atomic rename on POSIX; never leaves a half-written .json
+        except OSError as e:
+            logger.error(f"Could not persist pending metrics report for {key}: {e}", exc_info=True)
+
+    def _discard_report(self, key: str) -> None:
+        """Forget a snapshot (in memory and on disk) once it's been delivered or pruned."""
+        self.metrics_to_send.pop(key, None)
+        try:
+            self._report_path(key).unlink(missing_ok=True)
+        except OSError as e:
+            logger.error(f"Could not delete pending metrics report for {key}: {e}", exc_info=True)
+
+    def load_pending_reports(self) -> None:
+        """Reload snapshots that were queued before a restart. Call once at startup, before reporting."""
+        if not self.pending_reports_dir.exists():
+            return
+        for path in sorted(self.pending_reports_dir.glob("*.json")):
+            try:
+                self.metrics_to_send[path.stem] = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError) as e:
+                logger.error(f"Could not load pending metrics report {path}; deleting it: {e}", exc_info=True)
+                path.unlink(missing_ok=True)
+        if self.metrics_to_send:
+            logger.info(f"Reloaded {len(self.metrics_to_send)} pending metrics report(s) from disk.")
+
+    def _prune_stale_reports(self) -> None:
+        """Drop pending reports whose hour is older than ``PENDING_REPORT_MAX_AGE`` to bound disk growth."""
+        cutoff = datetime.now(timezone.utc) - PENDING_REPORT_MAX_AGE
+        for key in list(self.metrics_to_send):
+            try:
+                hour = datetime.strptime(key, "%Y-%m-%d_%H").replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue  # not an activity_hour key (in-memory fallback); leave it alone
+            if hour < cutoff:
+                logger.warning(
+                    f"Dropping undeliverable metrics report for activity_hour={key} "
+                    f"(older than {PENDING_REPORT_MAX_AGE})."
+                )
+                self._discard_report(key)
+
     def collect_metrics_for_cloud(self):
-        """Collect metrics for the cloud API."""
+        """Seal the previous hour's metrics once and queue them for delivery.
+
+        Keyed by ``activity_hour`` with first-writer-wins: if the hour has already been sealed
+        (earlier in this run, or persisted before a restart), we keep that snapshot instead of
+        re-reading the counters, which would yield a different total for the same immutable hour.
+        """
         payload = self.metrics_payload()
-        self.metrics_to_send[datetime.now().isoformat()] = payload
+        activity_hour = payload.get("activity_metrics", {}).get("activity_hour")
+
+        if not isinstance(activity_hour, str):
+            # Couldn't determine the hour (e.g. the clock read failed and SafeMetricsDict stored an
+            # error dict). Queue in memory under a unique key so we still attempt a send, but don't
+            # persist or dedup it.
+            logger.warning(f"No usable activity_hour in metrics payload; queueing without dedup. got={activity_hour!r}")
+            self.metrics_to_send[datetime.now().isoformat()] = payload
+            return
+
+        if activity_hour in self.metrics_to_send or self._report_path(activity_hour).exists():
+            logger.info(f"Metrics for activity_hour={activity_hour} already sealed; keeping the original snapshot.")
+            return
+
+        self._persist_report(activity_hour, payload)
+        self.metrics_to_send[activity_hour] = payload
 
     def report_metrics_to_cloud(self):
-        """Reports metrics to the cloud API."""
+        """Reports any queued (sealed) metrics snapshots to the cloud API."""
+        self._prune_stale_reports()
         sdk = _groundlight_client()
         # TODO: replace this with a proper SDK call when available.
         headers = sdk.api_client._headers()
 
-        for timestamp, payload in sorted(self.metrics_to_send.items(), key=lambda x: x[0]):
+        for key, payload in sorted(self.metrics_to_send.items(), key=lambda x: x[0]):
             logger.info(f"Reporting metrics to the cloud API: {payload}")
             response = sdk.api_client.call_api(
                 # We have to do this in order because it analyzes *args.  Grrr.
@@ -121,7 +215,7 @@ class MetricsReporter:
             # Returns a tuple of (return_data, status, headers)
             if response[1] == 200:
                 logger.info(f"Metrics reported successfully: {response}")
-                del self.metrics_to_send[timestamp]
+                self._discard_report(key)
             else:
                 logger.error(f"Error reporting metrics to the cloud API: {response}")
 
@@ -129,5 +223,6 @@ class MetricsReporter:
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     reporter = MetricsReporter()
+    reporter.load_pending_reports()
     reporter.collect_metrics_for_cloud()
     reporter.report_metrics_to_cloud()

--- a/app/status_monitor/status_web.py
+++ b/app/status_monitor/status_web.py
@@ -32,9 +32,13 @@ async def startup_event():
     )
     logging.info("Starting status-monitor server...")
     logging.info("Will report metrics to the cloud every hour")
-    # Every hour, on the hour, collect metrics to send to the cloud.
-    scheduler.add_job(reporter.collect_metrics_for_cloud, "cron", hour="*", minute="0")
-    # Every hour, try to report collected metrics to the cloud. Run at 3 minutes past the hour, with a jitter of 120
+    # Reload any snapshots that were queued but not yet delivered before a restart, so we re-send the
+    # identical sealed payload rather than re-reading (and possibly changing) the hourly counts.
+    reporter.load_pending_reports()
+    # A minute past the hour, seal the previous hour's metrics. The small offset lets the last
+    # in-flight image queries of the hour finish being counted before we snapshot.
+    scheduler.add_job(reporter.collect_metrics_for_cloud, "cron", hour="*", minute="1")
+    # A few minutes later, try to deliver collected metrics. Run at 3 minutes past the hour, with a jitter of 120
     # seconds, to avoid every edge-endpoint report hitting the server at the exact same time.
     scheduler.add_job(reporter.report_metrics_to_cloud, "cron", hour="*", minute="3", jitter=120)
     scheduler.add_job(clear_old_activity_files, "interval", seconds=ONE_HOUR_IN_SECONDS)

--- a/test/metrics/test_metric_reporting.py
+++ b/test/metrics/test_metric_reporting.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from app.metrics.metric_reporting import MetricsReporter, SafeMetricsDict
@@ -6,6 +7,23 @@ from app.metrics.metric_reporting import MetricsReporter, SafeMetricsDict
 
 def _deliberate_error():
     raise RuntimeError("Intentional test error")
+
+
+def _fake_payload(activity_hour: str, num_iqs: int = 100) -> dict:
+    """A minimal report payload with a controllable activity_hour and per-detector count."""
+    return {
+        "device_info": {"device_id": "device_test", "now": "2026-06-24T16:00:00"},
+        "activity_metrics": {
+            "activity_hour": activity_hour,
+            "detector_activity_previous_hour": json.dumps({"det_1": {"hourly_total_iqs": num_iqs}}),
+        },
+        "k3s_stats": {},
+    }
+
+
+def _reported_iqs(payload: dict) -> int:
+    """Pull det_1's hourly_total_iqs out of a (fake) payload."""
+    return json.loads(payload["activity_metrics"]["detector_activity_previous_hour"])["det_1"]["hourly_total_iqs"]
 
 
 class TestSafeMetricsDict:
@@ -109,18 +127,97 @@ class TestMetricsReporter:
         payload = reporter.metrics_payload()
         self._check_payload_structure(payload)
 
-    def test_collect_metrics_for_cloud(self):
-        """Test that metrics are collected correctly."""
-        reporter = MetricsReporter()
+    def test_collect_metrics_for_cloud(self, tmp_path):
+        """Metrics are collected and sealed once per hour (re-collecting the same hour is idempotent)."""
+        reporter = MetricsReporter(pending_reports_dir=tmp_path)
 
         reporter.collect_metrics_for_cloud()
         assert len(reporter.metrics_to_send) == 1
 
+        # Collecting again within the same hour is a no-op (first-writer-wins).
         reporter.collect_metrics_for_cloud()
-        assert len(reporter.metrics_to_send) == 2
+        assert len(reporter.metrics_to_send) == 1
 
-        _, payload = reporter.metrics_to_send.popitem()
+        _, payload = next(iter(reporter.metrics_to_send.items()))
         self._check_payload_structure(payload)
+
+    def test_collect_is_idempotent_per_hour(self, tmp_path):
+        """Two collections for the same hour keep the first sealed snapshot, even if the second read
+        would have produced different counts. This is the edge-side guard against the cloud's
+        "same key, different value" rejection."""
+        reporter = MetricsReporter(pending_reports_dir=tmp_path)
+
+        with patch.object(reporter, "metrics_payload", return_value=_fake_payload("2026-06-24_15", num_iqs=100)):
+            reporter.collect_metrics_for_cloud()
+        with patch.object(reporter, "metrics_payload", return_value=_fake_payload("2026-06-24_15", num_iqs=200)):
+            reporter.collect_metrics_for_cloud()
+
+        assert list(reporter.metrics_to_send) == ["2026-06-24_15"]
+        # The first snapshot is kept; the drifted re-read is ignored.
+        assert _reported_iqs(reporter.metrics_to_send["2026-06-24_15"]) == 100
+        assert (tmp_path / "2026-06-24_15.json").exists()
+
+    def test_pending_report_persisted_and_reloaded_after_restart(self, tmp_path):
+        """A queued snapshot survives a restart, and re-collecting that hour afterward stays deduped."""
+        reporter = MetricsReporter(pending_reports_dir=tmp_path)
+        with patch.object(reporter, "metrics_payload", return_value=_fake_payload("2026-06-24_15", num_iqs=100)):
+            reporter.collect_metrics_for_cloud()
+
+        # Simulate a restart: a brand-new reporter starts empty, then reloads from disk.
+        restarted = MetricsReporter(pending_reports_dir=tmp_path)
+        assert restarted.metrics_to_send == {}
+        restarted.load_pending_reports()
+        assert "2026-06-24_15" in restarted.metrics_to_send
+
+        # Re-collecting the same hour after a reload won't replace it with a freshly-read value.
+        with patch.object(restarted, "metrics_payload", return_value=_fake_payload("2026-06-24_15", num_iqs=999)):
+            restarted.collect_metrics_for_cloud()
+        assert len(restarted.metrics_to_send) == 1
+        assert _reported_iqs(restarted.metrics_to_send["2026-06-24_15"]) == 100
+
+    @patch("app.metrics.metric_reporting._groundlight_client")
+    def test_successful_send_removes_persisted_report(self, mock_gl_client, tmp_path):
+        """A 200 response clears the snapshot from memory and disk."""
+        mock_gl_client.return_value.api_client = self._get_mock_api_client(status_code=200)
+        reporter = MetricsReporter(pending_reports_dir=tmp_path)
+        with patch.object(reporter, "metrics_payload", return_value=_fake_payload("2026-06-24_15")):
+            reporter.collect_metrics_for_cloud()
+        assert (tmp_path / "2026-06-24_15.json").exists()
+
+        reporter.report_metrics_to_cloud()
+
+        assert reporter.metrics_to_send == {}
+        assert not (tmp_path / "2026-06-24_15.json").exists()
+
+    @patch("app.metrics.metric_reporting._groundlight_client")
+    def test_failed_send_keeps_persisted_report(self, mock_gl_client, tmp_path):
+        """A non-200 response keeps the snapshot queued (in memory and on disk) for a later retry."""
+        mock_gl_client.return_value.api_client = self._get_mock_api_client(status_code=400)
+        reporter = MetricsReporter(pending_reports_dir=tmp_path)
+        with patch.object(reporter, "metrics_payload", return_value=_fake_payload("2026-06-24_15")):
+            reporter.collect_metrics_for_cloud()
+
+        reporter.report_metrics_to_cloud()
+
+        assert "2026-06-24_15" in reporter.metrics_to_send
+        assert (tmp_path / "2026-06-24_15.json").exists()
+
+    def test_prune_drops_only_stale_reports(self, tmp_path):
+        """Reports older than the max age are dropped; fresh ones are retained."""
+        reporter = MetricsReporter(pending_reports_dir=tmp_path)
+        stale_hour = (datetime.now(timezone.utc) - timedelta(days=8)).strftime("%Y-%m-%d_%H")
+        fresh_hour = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime("%Y-%m-%d_%H")
+        for hour in (stale_hour, fresh_hour):
+            payload = _fake_payload(hour)
+            reporter._persist_report(hour, payload)
+            reporter.metrics_to_send[hour] = payload
+
+        reporter._prune_stale_reports()
+
+        assert stale_hour not in reporter.metrics_to_send
+        assert not (tmp_path / f"{stale_hour}.json").exists()
+        assert fresh_hour in reporter.metrics_to_send
+        assert (tmp_path / f"{fresh_hour}.json").exists()
 
     @patch("app.metrics.metric_reporting._groundlight_client")
     def test_report_single_metric_payload_to_cloud(self, mock_gl_client):


### PR DESCRIPTION
## What

Makes the edge-endpoint's hourly metrics reporting **single-shot and durable** so it never reports the same hour twice with different values.

## Why

The cloud `POST /v1/edge/report-metrics` endpoint stores each `(activity_hour, device, detector)` row **immutably** under a unique key. If the edge reports the same hour twice with *different* counts, the second is rejected with an `IntegrityError` → **HTTP 500**; and because a non-200 keeps the payload queued (`report_metrics_to_cloud` only drops on `200`), the edge **re-sends it every hour forever**. We saw exactly this in prod: one device re-sending the same hour-15 snapshot at 16:04 and 17:03, both 500-ing.

A second, *differently-valued* snapshot of the same hour can arise because the hourly counts are **live-incremented per-process files read at collection time** (`iq_activity.get_detector_activity_metrics` globs `*_<hour>` and sums them). A re-collection (scheduler misfire) or a retry **after a process restart** re-reads the counters and gets a different total for the same immutable hour. The payload is cached per collection, so retries *within* a process are identical — the divergence comes from a second **read**.

(The deployment is already `replicas: 1` and the status-monitor runs `--workers 1`, so "single reporter per device" is already satisfied; the realistic trigger is a misfire/restart re-read.)

## Changes (`app/metrics/metric_reporting.py`, `app/status_monitor/status_web.py`)

- **Key `metrics_to_send` by `activity_hour`, first-writer-wins.** Re-collecting an hour keeps the original sealed snapshot instead of re-reading drifted counts.
- **Persist each sealed snapshot to disk** (atomic write to `…/edge-metrics/pending-cloud-reports/<hour>.json`) and **reload on startup**, so a retry — even across a restart — re-sends the *identical bytes* rather than re-reading. Delete on a successful (200) send.
- **Prune** pending reports older than `PENDING_REPORT_MAX_AGE` (7d) to bound disk growth.
- **Seal at 1 minute past the hour** (was on the hour) so the last in-flight image queries of the hour are counted before the snapshot.

Net effect: the same hour is always sent with the same bytes, so the cloud's first-writer-wins matches and there's no permanent conflict — even if a send phantom-commits server-side and the edge retries after a restart.

## Tests

`test/metrics/test_metric_reporting.py` — added: idempotent per-hour collection (drifted re-read ignored), persist + reload across a simulated restart, 200 clears the on-disk snapshot, non-200 keeps it, and stale-report pruning. Updated `test_collect_metrics_for_cloud` for the new first-writer-wins semantics. **Full `test/metrics/` suite passes (96 passed)** locally via `uv run pytest`.

## Companion backend fix

The cloud-side safety net (stop the 500, first-writer-wins + warning) is in zuuul PR **#6539**. This PR removes the root cause on the edge.

## Known follow-up (not fixed here)

`activity_hour` is computed in **UTC** (`iq_activity.get_last_hour`) while the counter files are written/read in **local time** (`record_activity_for_metrics`, `_previous_hour_local`). On any non-UTC device the reported hour *label* is offset from the data window. Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)