### PR TITLE
fix: canonicalize mis-cased detector IDs on the edge

### DIFF
--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -115,9 +115,9 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
     # Ensure that detector_id has correct casing by pulling the detector ID out of detector_metadata
     # get_detector_metadata returns the correctly-cased, canonical detector ID
     detector_metadata = get_detector_metadata(detector_id=detector_id, gl=gl)  # NOTE: API call (once, then cached)
-    detector_id = detector_metadata.id
-    # Schedule a background task to refresh the detector metadata if it's too old.
+    # Refresh against the caller-supplied key, since that is the key this cache entry is stored under.
     background_tasks.add_task(refresh_detector_metadata_if_needed, detector_id, gl)
+    detector_id = detector_metadata.id
 
     require_human_review = human_review == "ALWAYS"
     edge_config = EdgeConfigManager.active()

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -112,12 +112,8 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
     # request was sent directly and not through the SDK) we generate one in the same way that the SDK does.
     request_id = request.headers.get("x-request-id") or generate_request_id()
 
-    # Resolve the detector to its canonical identity before keying any activity, config, or inference on it.
-    # Detector IDs are case-sensitive KSUIDs, but the cloud resolves them case-insensitively. A mis-cased ID
-    # would otherwise be tracked as a separate detector by the edge's case-sensitive subsystems (hourly activity
-    # folders, edge-config lookup), yielding incoherent metrics and duplicate-key failures when the cloud ingests
-    # them. Mirror the cloud's lenient resolution but canonicalize immediately, so a single detector is only ever
-    # keyed under one casing no matter how the caller spelled it.
+    # Canonicalize the (case-sensitive) detector ID up front so all downstream keying uses one casing,
+    # since the cloud resolves IDs case-insensitively and a mis-cased ID would otherwise be tracked separately.
     detector_metadata = get_detector_metadata(detector_id=detector_id, gl=gl)  # NOTE: API call (once, then cached)
     detector_id = detector_metadata.id
     # Schedule a background task to refresh the detector metadata if it's too old.

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -112,6 +112,24 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
     # request was sent directly and not through the SDK) we generate one in the same way that the SDK does.
     request_id = request.headers.get("x-request-id") or generate_request_id()
 
+    # Resolve the detector to its canonical identity before keying any activity, config, or inference on it.
+    # Detector IDs are case-sensitive KSUIDs, but the cloud resolves them case-insensitively. A mis-cased ID
+    # would therefore route to the correct model while being tracked as a separate detector by the edge's
+    # case-sensitive subsystems (hourly activity folders, edge-config lookup), yielding incoherent metrics and
+    # duplicate-key failures when the cloud ingests them. Reject the mismatch loudly so a single detector is
+    # only ever keyed under one canonical ID.
+    detector_metadata = get_detector_metadata(detector_id=detector_id, gl=gl)  # NOTE: API call (once, then cached)
+    if detector_id != detector_metadata.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"Unknown detector_id={detector_id!r}. Detector IDs are case-sensitive; "
+                f"did you mean {detector_metadata.id!r}?"
+            ),
+        )
+    # Schedule a background task to refresh the detector metadata if it's too old.
+    background_tasks.add_task(refresh_detector_metadata_if_needed, detector_id, gl)
+
     require_human_review = human_review == "ALWAYS"
     edge_config = EdgeConfigManager.active()
     detector_inference_config = EdgeConfigManager.detector_config(edge_config, detector_id)
@@ -154,11 +172,6 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
             submit_iq_params=submit_iq_params,
             request_id=request_id,
         )
-
-    # Confirm the existence of the detector in GL, get relevant metadata
-    detector_metadata = get_detector_metadata(detector_id=detector_id, gl=gl)  # NOTE: API call (once, then cached)
-    # Schedule a background task to refresh the detector metadata if it's too old
-    background_tasks.add_task(refresh_detector_metadata_if_needed, detector_id, gl)
 
     confidence_threshold = (
         confidence_threshold if confidence_threshold is not None else detector_metadata.confidence_threshold

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -112,8 +112,8 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
     # request was sent directly and not through the SDK) we generate one in the same way that the SDK does.
     request_id = request.headers.get("x-request-id") or generate_request_id()
 
-    # Canonicalize the (case-sensitive) detector ID up front so all downstream keying uses one casing,
-    # since the cloud resolves IDs case-insensitively and a mis-cased ID would otherwise be tracked separately.
+    # Ensure that detector_id has correct casing by pulling the detector ID out of detector_metadata
+    # get_detector_metadata returns the correctly-cased, canonical detector ID
     detector_metadata = get_detector_metadata(detector_id=detector_id, gl=gl)  # NOTE: API call (once, then cached)
     detector_id = detector_metadata.id
     # Schedule a background task to refresh the detector metadata if it's too old.

--- a/app/api/routes/image_queries.py
+++ b/app/api/routes/image_queries.py
@@ -114,19 +114,12 @@ async def post_image_query(  # noqa: PLR0913, PLR0915, PLR0912
 
     # Resolve the detector to its canonical identity before keying any activity, config, or inference on it.
     # Detector IDs are case-sensitive KSUIDs, but the cloud resolves them case-insensitively. A mis-cased ID
-    # would therefore route to the correct model while being tracked as a separate detector by the edge's
-    # case-sensitive subsystems (hourly activity folders, edge-config lookup), yielding incoherent metrics and
-    # duplicate-key failures when the cloud ingests them. Reject the mismatch loudly so a single detector is
-    # only ever keyed under one canonical ID.
+    # would otherwise be tracked as a separate detector by the edge's case-sensitive subsystems (hourly activity
+    # folders, edge-config lookup), yielding incoherent metrics and duplicate-key failures when the cloud ingests
+    # them. Mirror the cloud's lenient resolution but canonicalize immediately, so a single detector is only ever
+    # keyed under one casing no matter how the caller spelled it.
     detector_metadata = get_detector_metadata(detector_id=detector_id, gl=gl)  # NOTE: API call (once, then cached)
-    if detector_id != detector_metadata.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=(
-                f"Unknown detector_id={detector_id!r}. Detector IDs are case-sensitive; "
-                f"did you mean {detector_metadata.id!r}?"
-            ),
-        )
+    detector_id = detector_metadata.id
     # Schedule a background task to refresh the detector metadata if it's too old.
     background_tasks.add_task(refresh_detector_metadata_if_needed, detector_id, gl)
 

--- a/test/api/test_image_queries.py
+++ b/test/api/test_image_queries.py
@@ -293,7 +293,9 @@ def test_post_image_query_canonicalizes_miscased_detector_id(test_client: TestCl
     miscased_id = detector.id.upper()  # same KSUID, wrong casing
     assert miscased_id != detector.id
 
-    with assert_escalated_to_gl(detector=detector, sdk_response=confident_cloud_iq):
+    with assert_escalated_to_gl(
+        detector=detector, sdk_response=confident_cloud_iq, submitted_with={"detector": detector.id}
+    ):
         with mock.patch("app.api.routes.image_queries.record_activity_for_metrics") as mock_record:
             response = test_client.post(
                 url,

--- a/test/api/test_image_queries.py
+++ b/test/api/test_image_queries.py
@@ -282,26 +282,29 @@ def test_post_image_query_with_invalid_detector_id(test_client: TestClient, dete
     assert response.json() == {"detail": "Detector with id 'invalid_id' not found"}
 
 
-def test_post_image_query_rejects_miscased_detector_id(test_client: TestClient, detector: Detector):
-    """A detector_id whose casing differs from the canonical ID is rejected with 404 and not escalated.
+def test_post_image_query_canonicalizes_miscased_detector_id(test_client: TestClient, detector: Detector):
+    """A mis-cased detector_id is accepted but tracked under the canonical casing.
 
-    The cloud resolves detector IDs case-insensitively, so a mis-cased ID still resolves to the real
-    detector. The edge must reject it so a single detector is never tracked under two case variants.
+    The cloud resolves detector IDs case-insensitively, so the edge mirrors that leniency. To avoid a single
+    detector being split across two case variants in edge metrics, the handler canonicalizes the ID up front
+    so every activity record is keyed on the canonical casing regardless of how the caller spelled it.
     """
     image_bytes = pil_image_to_bytes(img=Image.open("test/assets/dog.jpeg"))
     miscased_id = detector.id.upper()  # same KSUID, wrong casing
     assert miscased_id != detector.id
 
-    with assert_not_escalated_to_gl(detector=detector):
-        response = test_client.post(
-            url,
-            headers={"Content-Type": "image/jpeg"},
-            content=image_bytes,
-            params={"detector_id": miscased_id, "confidence_threshold": 1.0},
-        )
+    with assert_escalated_to_gl(detector=detector, sdk_response=confident_cloud_iq):
+        with mock.patch("app.api.routes.image_queries.record_activity_for_metrics") as mock_record:
+            response = test_client.post(
+                url,
+                headers={"Content-Type": "image/jpeg"},
+                content=image_bytes,
+                params={"detector_id": miscased_id, "confidence_threshold": 1.0},
+            )
 
-    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()["detail"]
-    assert miscased_id in response.json()["detail"]
+    assert response.status_code == status.HTTP_200_OK, response.json()["detail"]
+    recorded_ids = {call.args[0] for call in mock_record.call_args_list}
+    assert recorded_ids == {detector.id}, f"metrics keyed on non-canonical IDs: {recorded_ids}"
 
 
 def test_post_image_query_with_invalid_field(test_client: TestClient, detector: Detector):

--- a/test/api/test_image_queries.py
+++ b/test/api/test_image_queries.py
@@ -282,6 +282,28 @@ def test_post_image_query_with_invalid_detector_id(test_client: TestClient, dete
     assert response.json() == {"detail": "Detector with id 'invalid_id' not found"}
 
 
+def test_post_image_query_rejects_miscased_detector_id(test_client: TestClient, detector: Detector):
+    """A detector_id whose casing differs from the canonical ID is rejected with 404 and not escalated.
+
+    The cloud resolves detector IDs case-insensitively, so a mis-cased ID still resolves to the real
+    detector. The edge must reject it so a single detector is never tracked under two case variants.
+    """
+    image_bytes = pil_image_to_bytes(img=Image.open("test/assets/dog.jpeg"))
+    miscased_id = detector.id.upper()  # same KSUID, wrong casing
+    assert miscased_id != detector.id
+
+    with assert_not_escalated_to_gl(detector=detector):
+        response = test_client.post(
+            url,
+            headers={"Content-Type": "image/jpeg"},
+            content=image_bytes,
+            params={"detector_id": miscased_id, "confidence_threshold": 1.0},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()["detail"]
+    assert miscased_id in response.json()["detail"]
+
+
 def test_post_image_query_with_invalid_field(test_client: TestClient, detector: Detector):
     """Test submitting an image query with an invalid detector ID."""
     image_bytes = pil_image_to_bytes(img=Image.open("test/assets/dog.jpeg"))


### PR DESCRIPTION
## Summary

Detector IDs are case-sensitive KSUIDs, but the cloud resolves them case-insensitively.
A mis-cased ID still resolves to the right detector and routes to the right inference pod,
but the edge's case-sensitive subsystems (hourly activity folders, edge-config lookup)
track it as a separate detector. This splits edge metrics into two buckets for one
detector, which then collide on the cloud's case-insensitive unique index
`(log_hour, group_id, device_id, detector_id)`, causing `IntegrityError` duplicate-key
failures and silent data loss.

## Fix

Resolve detector metadata up front and rebind `detector_id` to the canonical
`detector_metadata.id` before anything keys off it. Every downstream consumer (metrics,
edge-config lookup, inference routing, escalation) then uses one canonical casing,
regardless of caller spelling or whether the detector has an edge inference pod. This
mirrors the cloud's lenient resolution, replacing the earlier 404-rejection approach.

## Test plan

- [x] `test_post_image_query_canonicalizes_miscased_detector_id`: an upper-cased ID
      returns 200 and all metrics are keyed on the canonical `detector.id`.
- [x] Deploy changes to an edge endpoint and test that mixed-case submissions no longer split metric buckets.