### PR TITLE
Make status page detector links point to the correct dashboard per environment

### DIFF
--- a/app/core/groundlight_client.py
+++ b/app/core/groundlight_client.py
@@ -1,0 +1,15 @@
+from functools import lru_cache
+
+from groundlight import Groundlight
+
+
+@lru_cache(maxsize=1)
+def groundlight_client() -> Groundlight:
+    """Return a cached, endpoint-wide Groundlight client for talking to the cloud.
+
+    Authenticates with the endpoint's environment-provided API token and cloud endpoint
+    (GROUNDLIGHT_API_TOKEN / GROUNDLIGHT_ENDPOINT), so it always points at the cloud this
+    device is registered to.
+    """
+    # Don't specify an API token here - it will use the environment variable.
+    return Groundlight()  # NOTE this will wait the default 10 seconds when there's no connection.

--- a/app/escalation_queue/manage_reader.py
+++ b/app/escalation_queue/manage_reader.py
@@ -2,13 +2,13 @@ import json
 import logging
 import os
 import time
-from functools import lru_cache
 from pathlib import Path
 
 from fastapi import HTTPException, status
-from groundlight import Groundlight, GroundlightClientError, ImageQuery
+from groundlight import GroundlightClientError, ImageQuery
 from urllib3.exceptions import MaxRetryError, ReadTimeoutError
 
+from app.core.groundlight_client import groundlight_client
 from app.core.utils import safe_call_sdk
 from app.escalation_queue.failed_escalations import record_failed_escalation
 from app.escalation_queue.models import EscalationInfo
@@ -24,13 +24,6 @@ logger = logging.getLogger(__name__)
 # Increasing lengths of time to wait before retrying an escalation, to avoid hammering the cloud
 # service if it's down for some reason or if the user's throttling limit is reached.
 RETRY_WAIT_TIMES = [0, 1, 5, 10, 30]
-
-
-@lru_cache(maxsize=1)
-def _groundlight_client() -> Groundlight:
-    """Returns a Groundlight client instance with EE-wide credentials for escalating from the queue."""
-    # Don't specify an API token here - it will use the environment variable.
-    return Groundlight()  # NOTE this will wait the default 10 seconds when there's no connection.
 
 
 def _escalate_once(escalation_info: EscalationInfo, submit_iq_request_timeout_s: int | tuple[int, int]) -> ImageQuery:
@@ -51,7 +44,7 @@ def _escalate_once(escalation_info: EscalationInfo, submit_iq_request_timeout_s:
         f"Escalating queued escalation with ID {escalation_info.submit_iq_params.image_query_id} for detector "
         f"{escalation_info.detector_id} with timestamp {escalation_info.timestamp}."
     )
-    gl = _groundlight_client()
+    gl = groundlight_client()
     image_path = Path(escalation_info.image_path_str)
     image_bytes = image_path.read_bytes()
     submit_iq_params = escalation_info.submit_iq_params

--- a/app/metrics/metric_reporting.py
+++ b/app/metrics/metric_reporting.py
@@ -7,23 +7,14 @@ import json
 import logging
 import os
 from datetime import datetime, timedelta
-from functools import lru_cache
 from typing import Any, Callable
 
-from groundlight import Groundlight
-
 from app.core import deviceid
+from app.core.groundlight_client import groundlight_client
 from app.escalation_queue import failed_escalations
 from app.metrics import iq_activity, system_metrics
 
 logger = logging.getLogger(__name__)
-
-
-@lru_cache(maxsize=1)
-def _groundlight_client() -> Groundlight:
-    """Returns a Groundlight client instance with EE-wide credentials for reporting metrics."""
-    # Don't specify an API token here - it will use the environment variable.
-    return Groundlight()
 
 
 class SafeMetricsDict:
@@ -101,7 +92,7 @@ class MetricsReporter:
 
     def report_metrics_to_cloud(self):
         """Reports metrics to the cloud API."""
-        sdk = _groundlight_client()
+        sdk = groundlight_client()
         # TODO: replace this with a proper SDK call when available.
         headers = sdk.api_client._headers()
 

--- a/app/status_monitor/dev/mock_server.py
+++ b/app/status_monitor/dev/mock_server.py
@@ -361,6 +361,8 @@ class MockHandler(BaseHTTPRequestHandler):
                 data = build_metrics(state)
             elif self.path == "/status/edge-config":
                 data = build_edge_config(state)
+            elif self.path == "/status/cloud-config":
+                data = {"dashboard_url": "https://dashboard.groundlight.ai"}
             else:
                 self.send_error(404)
                 return

--- a/app/status_monitor/frontend/src/App.jsx
+++ b/app/status_monitor/frontend/src/App.jsx
@@ -220,6 +220,7 @@ export default function App() {
   const [resources, setResources] = useState(null);
   const [edgeConfig, setEdgeConfig] = useState(null);
   const [edgeConfigError, setEdgeConfigError] = useState(false);
+  const [dashboardUrl, setDashboardUrl] = useState("https://dashboard.groundlight.ai");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const intervalRef = useRef(null);
@@ -258,6 +259,17 @@ export default function App() {
     } catch {
       setEdgeConfigError(true);
     }
+  }, []);
+
+  // The dashboard URL is static deployment config, so fetch it once on mount rather
+  // than on every poll. Falls back to the prod dashboard if the request fails.
+  useEffect(() => {
+    fetch("/status/cloud-config")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.dashboard_url) setDashboardUrl(data.dashboard_url);
+      })
+      .catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -322,7 +334,7 @@ export default function App() {
 
         <Stack gap="xl">
           <CollapsibleSection title="Detector Details">
-            <DetectorDetails details={detectorDetails} loading={loading} />
+            <DetectorDetails details={detectorDetails} loading={loading} dashboardUrl={dashboardUrl} />
           </CollapsibleSection>
 
           <CollapsibleSection title="Resource Usage by Detector">

--- a/app/status_monitor/frontend/src/components/DetectorDetails.jsx
+++ b/app/status_monitor/frontend/src/components/DetectorDetails.jsx
@@ -197,7 +197,7 @@ function getTimestamp(info) {
   return Number.isNaN(t) ? Date.now() : t;
 }
 
-export default function DetectorDetails({ details, loading }) {
+export default function DetectorDetails({ details, loading, dashboardUrl = "https://dashboard.groundlight.ai" }) {
   // null = default sort by deployment creation time (oldest first)
   const [sortDir, setSortDir] = useState(null);
 
@@ -283,8 +283,9 @@ export default function DetectorDetails({ details, loading }) {
                 <Table.Td style={{ verticalAlign: "top", overflow: "hidden" }}>
                   <Stack gap={4}>
                     <Anchor
-                      href={`https://dashboard.groundlight.ai/reef/detectors/${id}`}
+                      href={`${dashboardUrl}/reef/detectors/${id}`}
                       target="_blank"
+                      rel="noopener noreferrer"
                       size="sm"
                       underline="always"
                       style={{ whiteSpace: "nowrap" }}

--- a/app/status_monitor/frontend/vite.config.js
+++ b/app/status_monitor/frontend/vite.config.js
@@ -20,6 +20,7 @@ export default defineConfig({
       "/status/static/icon_gold_dark.svg": EDGE_ENDPOINT,
       "/status/static/favicon.ico": EDGE_ENDPOINT,
       "/status/edge-config": EDGE_ENDPOINT,
+      "/status/cloud-config": EDGE_ENDPOINT,
     },
   },
 });

--- a/app/status_monitor/status_web.py
+++ b/app/status_monitor/status_web.py
@@ -9,8 +9,9 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.core.edge_config_manager import EdgeConfigManager
+from app.core.groundlight_client import groundlight_client
 from app.metrics.iq_activity import clear_old_activity_files
-from app.metrics.metric_reporting import MetricsReporter, _groundlight_client
+from app.metrics.metric_reporting import MetricsReporter
 from app.metrics.resource_metrics import ResourceMetricsCollector
 
 ONE_HOUR_IN_SECONDS = 3600
@@ -21,14 +22,18 @@ REACT_BUILD_DIR = Path(__file__).parent / "react-build"
 
 
 def cloud_dashboard_url() -> str:
-    """Derive the Cloud Dashboard base URL from the SDK client's configured cloud endpoint."""
-    parsed = urlparse(_groundlight_client().endpoint)
-    host = parsed.hostname or ""
+    """Derive the Cloud Dashboard base URL from the SDK client's configured cloud endpoint.
+
+    Always uses https, since every Groundlight cloud is served over https.
+    """
+    host = urlparse(groundlight_client().endpoint).hostname
+    if not host:
+        raise ValueError("Could not determine cloud host from the Groundlight client endpoint.")
     if host.startswith("api."):
         dashboard_host = "dashboard." + host[len("api.") :]
     else:
         dashboard_host = "dashboard." + host
-    return f"{parsed.scheme or 'https'}://{dashboard_host}"
+    return f"https://{dashboard_host}"
 
 
 app = FastAPI(title="status-monitor")

--- a/app/status_monitor/status_web.py
+++ b/app/status_monitor/status_web.py
@@ -22,11 +22,6 @@ REACT_BUILD_DIR = Path(__file__).parent / "react-build"
 
 def cloud_dashboard_url() -> str:
     """Derive the Cloud Dashboard base URL from the SDK client's configured cloud endpoint.
-
-    The Groundlight SDK already knows which cloud this device is registered to, so we read its
-    endpoint and swap the leading 'api.' host label for 'dashboard.' (e.g.
-    'https://api.integ.groundlight.ai' -> 'https://dashboard.integ.groundlight.ai'). Detector
-    links then resolve to the right dashboard across prod, integ, dev, us1, etc.
     """
     parsed = urlparse(_groundlight_client().endpoint)
     host = parsed.hostname or ""

--- a/app/status_monitor/status_web.py
+++ b/app/status_monitor/status_web.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from pathlib import Path
+from urllib.parse import urlparse, urlunparse
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI
@@ -17,6 +18,26 @@ LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 
 STATIC_DIR = Path(__file__).parent / "static"
 REACT_BUILD_DIR = Path(__file__).parent / "react-build"
+
+
+def cloud_dashboard_url() -> str:
+    """Derive the Cloud Dashboard base URL from the cloud API endpoint.
+
+    Swaps a leading 'api.' host label for 'dashboard.' so e.g.
+    'https://api.groundlight.ai' becomes 'https://dashboard.groundlight.ai'. On the
+    edge endpoint GROUNDLIGHT_ENDPOINT already points at the real cloud, so detector
+    links resolve to the right dashboard for whichever cloud the device is registered
+    to (prod, integ, dev, us1, ...).
+    """
+    endpoint = os.environ.get("GROUNDLIGHT_ENDPOINT", "https://api.groundlight.ai")
+    parsed = urlparse(endpoint)
+    host = parsed.hostname or ""
+    if host.startswith("api."):
+        dashboard_host = "dashboard." + host[len("api.") :]
+    else:
+        dashboard_host = "dashboard." + host
+    return urlunparse(parsed._replace(netloc=dashboard_host, path="", params="", query="", fragment=""))
+
 
 app = FastAPI(title="status-monitor")
 scheduler = AsyncIOScheduler()
@@ -62,6 +83,13 @@ def get_edge_config():
     edge-endpoint API also exposes /edge-config for SDK and tooling use.
     """
     return EdgeConfigManager.active().to_payload()
+
+
+@app.get("/status/cloud-config")
+def get_cloud_config():
+    """Return cloud-derived config for the status UI, such as the Cloud Dashboard base
+    URL used to build detector links."""
+    return {"dashboard_url": cloud_dashboard_url()}
 
 
 @app.get("/status")

--- a/app/status_monitor/status_web.py
+++ b/app/status_monitor/status_web.py
@@ -21,8 +21,7 @@ REACT_BUILD_DIR = Path(__file__).parent / "react-build"
 
 
 def cloud_dashboard_url() -> str:
-    """Derive the Cloud Dashboard base URL from the SDK client's configured cloud endpoint.
-    """
+    """Derive the Cloud Dashboard base URL from the SDK client's configured cloud endpoint."""
     parsed = urlparse(_groundlight_client().endpoint)
     host = parsed.hostname or ""
     if host.startswith("api."):

--- a/app/status_monitor/status_web.py
+++ b/app/status_monitor/status_web.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI
@@ -10,7 +10,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.core.edge_config_manager import EdgeConfigManager
 from app.metrics.iq_activity import clear_old_activity_files
-from app.metrics.metric_reporting import MetricsReporter
+from app.metrics.metric_reporting import MetricsReporter, _groundlight_client
 from app.metrics.resource_metrics import ResourceMetricsCollector
 
 ONE_HOUR_IN_SECONDS = 3600
@@ -21,22 +21,20 @@ REACT_BUILD_DIR = Path(__file__).parent / "react-build"
 
 
 def cloud_dashboard_url() -> str:
-    """Derive the Cloud Dashboard base URL from the cloud API endpoint.
+    """Derive the Cloud Dashboard base URL from the SDK client's configured cloud endpoint.
 
-    Swaps a leading 'api.' host label for 'dashboard.' so e.g.
-    'https://api.groundlight.ai' becomes 'https://dashboard.groundlight.ai'. On the
-    edge endpoint GROUNDLIGHT_ENDPOINT already points at the real cloud, so detector
-    links resolve to the right dashboard for whichever cloud the device is registered
-    to (prod, integ, dev, us1, ...).
+    The Groundlight SDK already knows which cloud this device is registered to, so we read its
+    endpoint and swap the leading 'api.' host label for 'dashboard.' (e.g.
+    'https://api.integ.groundlight.ai' -> 'https://dashboard.integ.groundlight.ai'). Detector
+    links then resolve to the right dashboard across prod, integ, dev, us1, etc.
     """
-    endpoint = os.environ.get("GROUNDLIGHT_ENDPOINT", "https://api.groundlight.ai")
-    parsed = urlparse(endpoint)
+    parsed = urlparse(_groundlight_client().endpoint)
     host = parsed.hostname or ""
     if host.startswith("api."):
         dashboard_host = "dashboard." + host[len("api.") :]
     else:
         dashboard_host = "dashboard." + host
-    return urlunparse(parsed._replace(netloc=dashboard_host, path="", params="", query="", fragment=""))
+    return f"{parsed.scheme or 'https'}://{dashboard_host}"
 
 
 app = FastAPI(title="status-monitor")

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -231,6 +231,8 @@ spec:
         env:
         - name: LOG_LEVEL
           value: {{ .Values.logLevel | quote }}
+        - name: GROUNDLIGHT_ENDPOINT
+          value: "{{ .Values.upstreamEndpoint }}"
         - name: GROUNDLIGHT_API_TOKEN
           valueFrom:
             secretKeyRef:

--- a/test/escalation_queue/test_escalation_queue.py
+++ b/test/escalation_queue/test_escalation_queue.py
@@ -362,7 +362,7 @@ class TestQueueReader:
 class TestEscalateOnce:
     @pytest.fixture
     def mock_gl(self):
-        with patch("app.escalation_queue.manage_reader._groundlight_client") as mock_gl:
+        with patch("app.escalation_queue.manage_reader.groundlight_client") as mock_gl:
             mock_gl.return_value = Mock()
             yield mock_gl.return_value
 
@@ -415,7 +415,7 @@ class TestEscalateOnce:
 
     def test_gl_client_creation_failure(self, test_escalation_info: EscalationInfo):
         """If the Groundlight client cannot be created, _escalate_once should raise."""
-        with patch("app.escalation_queue.manage_reader._groundlight_client") as mock_gl:
+        with patch("app.escalation_queue.manage_reader.groundlight_client") as mock_gl:
             mock_gl.side_effect = GroundlightClientError()
             with pytest.raises(GroundlightClientError):
                 _escalate_once(test_escalation_info, submit_iq_request_timeout_s=5)

--- a/test/metrics/test_metric_reporting.py
+++ b/test/metrics/test_metric_reporting.py
@@ -122,7 +122,7 @@ class TestMetricsReporter:
         _, payload = reporter.metrics_to_send.popitem()
         self._check_payload_structure(payload)
 
-    @patch("app.metrics.metric_reporting._groundlight_client")
+    @patch("app.metrics.metric_reporting.groundlight_client")
     def test_report_single_metric_payload_to_cloud(self, mock_gl_client):
         """Test that a single metric payload is reported correctly."""
         mock_api_client = self._get_mock_api_client()
@@ -137,7 +137,7 @@ class TestMetricsReporter:
 
         assert len(reporter.metrics_to_send) == 0
 
-    @patch("app.metrics.metric_reporting._groundlight_client")
+    @patch("app.metrics.metric_reporting.groundlight_client")
     def test_report_multiple_metric_payloads_to_cloud(self, mock_gl_client):
         """Test that multiple metric payloads are reported correctly."""
         mock_api_client = self._get_mock_api_client()
@@ -155,7 +155,7 @@ class TestMetricsReporter:
         assert mock_api_client.call_api.call_count == 3
         assert len(reporter.metrics_to_send) == 0
 
-    @patch("app.metrics.metric_reporting._groundlight_client")
+    @patch("app.metrics.metric_reporting.groundlight_client")
     def test_report_metric_payload_to_cloud_failure(self, mock_gl_client):
         """Test that a metric payload is kept in metrics_to_send if the cloud API call fails."""
         mock_api_client = self._get_mock_api_client(status_code=400)
@@ -175,7 +175,7 @@ class TestMetricsReporter:
         assert len(reporter.metrics_to_send) == 3
         assert reporter.metrics_to_send == mock_metrics
 
-    @patch("app.metrics.metric_reporting._groundlight_client")
+    @patch("app.metrics.metric_reporting.groundlight_client")
     def test_report_metric_payload_empty_metrics_to_send(self, mock_gl_client):
         """Test that a metric payload is kept in metrics_to_send if the cloud API call fails."""
         mock_api_client = self._get_mock_api_client(status_code=400)

--- a/test/status_monitor/test_status_web.py
+++ b/test/status_monitor/test_status_web.py
@@ -1,0 +1,24 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+# status_web mounts the React build directory at import time, which only exists in the built
+# image, so stub out StaticFiles to import the pure cloud_dashboard_url() helper under test.
+with patch("fastapi.staticfiles.StaticFiles"):
+    from app.status_monitor.status_web import cloud_dashboard_url
+
+
+@pytest.mark.parametrize(
+    "cloud_endpoint, expected_dashboard_url",
+    [
+        ("https://api.groundlight.ai/device-api", "https://dashboard.groundlight.ai"),
+        ("https://api.integ.groundlight.ai/device-api", "https://dashboard.integ.groundlight.ai"),
+        ("https://api.dev.groundlight.ai/device-api", "https://dashboard.dev.groundlight.ai"),
+        ("https://api.groundlight.dev.axon.com/device-api", "https://dashboard.groundlight.dev.axon.com"),
+        ("https://api.groundlight.us1.axon.com/device-api", "https://dashboard.groundlight.us1.axon.com"),
+    ],
+)
+def test_cloud_dashboard_url_swaps_api_for_dashboard(cloud_endpoint, expected_dashboard_url):
+    """The dashboard URL is derived from the cloud endpoint by swapping the leading 'api.' host label."""
+    with patch("app.status_monitor.status_web.groundlight_client", return_value=Mock(endpoint=cloud_endpoint)):
+        assert cloud_dashboard_url() == expected_dashboard_url


### PR DESCRIPTION
## Problem

Detector ID links on the "Groundlight Edge Endpoint Status" page hardcoded `https://dashboard.groundlight.ai`, so they only resolved correctly on legacy prod. On integ/dev/us1 they pointed at the wrong dashboard.


## Solution
This PR derives the Cloud Dashboard base URL at runtime from the Groundlight SDK client, which already knows which cloud this device is registered to. It swaps the leading `api.` host label for `dashboard.`, so links resolve correctly everywhere:

- `api.groundlight.ai` -> `dashboard.groundlight.ai`
- `api.integ.groundlight.ai` -> `dashboard.integ.groundlight.ai`
- `api.dev.groundlight.ai` -> `dashboard.dev.groundlight.ai`
- `api.groundlight.dev.axon.com` -> `dashboard.groundlight.dev.axon.com`
- `api.groundlight.us1.axon.com` -> `dashboard.groundlight.us1.axon.com`

## How it works

- `status_web.py` (the web layer that backs the status page) gains a `cloud_dashboard_url()` helper and a `GET /status/cloud-config` endpoint. The helper reads the endpoint from the EE-wide SDK client and applies the `api.` -> `dashboard.` swap. It always builds an `https` URL (every Groundlight cloud is served over https, including eksdev) and raises if the client endpoint has no host, rather than emitting a malformed URL. Keeping this in `status_web.py` (rather than the cloud-bound metrics payload) avoids polluting cloud telemetry with a UI string.
- The React app fetches `/status/cloud-config` once on mount and passes the base URL to `DetectorDetails`, which builds `${dashboardUrl}/reef/detectors/${id}`. It falls back to `https://dashboard.groundlight.ai` if the fetch fails.
- The detector links already opened in a new tab; added `rel="noopener noreferrer"` for safety.
- Dev tooling (mock server + Vite proxy) updated so the new endpoint works locally.

## Deployment fix (required for this to work)

The `status-monitor` container, which serves `/status/cloud-config`, was the only cloud-talking container in the Helm chart without `GROUNDLIGHT_ENDPOINT` injected. Without it, `Groundlight()` defaulted to prod, its connectivity check rejected the non-prod token, `/status/cloud-config` returned HTTP 500, and the page silently fell back to the hardcoded prod dashboard. The chart now injects `GROUNDLIGHT_ENDPOINT` (from `upstreamEndpoint`) into the status-monitor container, matching the other containers.

This same gap was also silently breaking hourly metric reporting from the status-monitor on non-prod deployments (it used the same client against prod with a non-prod token), so this fix repairs that too.

## Refactor

Consolidated three near-duplicate Groundlight client factories into a single cached, endpoint-wide `app/core/groundlight_client.py::groundlight_client()`. `status_web.py`, `metric_reporting.py`, and `manage_reader.py` now share it, removing the duplicated private `_groundlight_client` helpers (and the cross-module import of a private symbol). Test patch targets updated accordingly.

## Test plan

- [x] On a non-prod deployment (dev), confirm `/status/cloud-config` returns the matching `dashboard.*` host and detector links open the detector page on that dashboard in a new tab.
- [x] Confirm prod behavior is unchanged (`dashboard.groundlight.ai`).
