### PR TITLE
fix: patch OpenSSL in balena-k3s server images (CVE-2026-45447)

### DIFF
--- a/deploy/balena-k3s/server/Dockerfile
+++ b/deploy/balena-k3s/server/Dockerfile
@@ -52,7 +52,7 @@ ARG K3S_TAG="v1.28.8+k3s1"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV K3S_TAG=${K3S_TAG}
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl runc systemd ca-certificates kmod procps gnupg iptables && \
     rm -rf /var/lib/apt/lists/*
 

--- a/deploy/balena-k3s/server/Dockerfile.gpu
+++ b/deploy/balena-k3s/server/Dockerfile.gpu
@@ -111,7 +111,7 @@ ENV K3S_TAG=${K3S_TAG}
 ENV NVIDIA_DRIVER_VERSION=${NVIDIA_DRIVER_VERSION}
 ENV NVIDIA_DRIVER=NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl runc systemd ca-certificates kmod procps gnupg2 iptables && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Why

The CPU and GPU k3s-server images (`deploy/balena-k3s/server/Dockerfile`, `Dockerfile.gpu`) run on `ubuntu:22.04`. The frozen base ships **libssl3 3.0.2-0ubuntu1.23**, flagged **High** by Snyk as `SNYK-UBUNTU2204-OPENSSL` (CVE-2026-45447) — the 2 remaining Fixable High container findings. The existing apt block installs packages but never upgrades the pre-installed OpenSSL.

## What

Add `apt-get upgrade -y` to the final-stage apt block in both Dockerfiles. Stays on `ubuntu:22.04` deliberately — a 24.04 jump would disturb the tuned NVIDIA driver / kernel-module build and k3s install. `apt upgrade` is the minimal, Snyk-recognized fix (in-place security updates, no package add/remove).

## Verification

On `ubuntu:22.04`:
```
base:           libssl3 3.0.2-0ubuntu1.23   (vulnerable, frozen)
after upgrade:  libssl3 3.0.2-0ubuntu1.25   (jammy-security)
```
Clears the finding. Also pulls other base security updates (libgnutls30, libsystemd0, perl-base, etc).

Full image builds (nvidia driver, kernel modules, k3s, airgap preloads) run in CI / on the balena builder — out of scope for a local build. The OpenSSL upgrade mechanism is verified above independently.

## Context

> **Stacked on #441** (bookworm base-image bumps). Merge #441 first; this branch is based on it.

Clears the last 2 Fixable High container findings from the Snyk triage. Together with #440 (canary, merged), #441, and #444 (zlib risk-accept), this leaves only the 2 Snyk Code SSRF Highs open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)