### PR TITLE
fix: respect DISABLE_TLS_VERIFY in load-testing call_api()

### DIFF
--- a/load-testing/groundlight_helpers.py
+++ b/load-testing/groundlight_helpers.py
@@ -60,7 +60,8 @@ def call_api(url: str, params: dict, timeout: float | None = None) -> dict:
         "X-API-Token": os.environ.get('GROUNDLIGHT_API_TOKEN')
     }
 
-    response = requests.get(url, params=params, headers=headers, timeout=timeout)
+    disable_tls = os.environ.get('DISABLE_TLS_VERIFY', '0') == '1'
+    response = requests.get(url, params=params, headers=headers, timeout=timeout, verify=not disable_tls)
     if response.status_code == 200:
         response_content = response.content.decode('utf-8')
         return json.loads(response_content)


### PR DESCRIPTION
## What

`call_api()` in `groundlight_helpers.py` is the shared helper all load-testing scripts use to hit the edge status endpoints (`/status/resources.json`, `/status/metrics.json`, etc). It was making raw `requests.get()` calls without respecting `DISABLE_TLS_VERIFY`, so SSL verification failures would occur when testing against an HTTPS endpoint with a self-signed cert — even if the Groundlight SDK itself had verification disabled via `DISABLE_TLS_VERIFY=1`.

The fix: check `DISABLE_TLS_VERIFY` in `call_api()` and pass `verify=False` accordingly, matching the SDK's behavior.

## Impact

Any load-testing script that calls `call_api()` — including `SystemMonitor` in `system_helpers.py`, `measure_ram_and_vram_usage.py`, and others — will now work correctly when `GROUNDLIGHT_ENDPOINT` is an `https://` URL with a self-signed cert. The only other raw `requests.get` in the directory (`plot_gpu_usage.py`) is hardcoded to `http://` against internal pod IPs and is unaffected.