### PR TITLE
fix: add iptables-legacy FORWARD rules for k3s pod/service networks

### DIFF
--- a/deploy/balena-k3s/server/server.sh
+++ b/deploy/balena-k3s/server/server.sh
@@ -48,6 +48,27 @@ if iptables -t nat -L CNI-HOSTPORT-DNAT -n >/dev/null 2>&1; then
     echo "CNI portmap cleanup complete"
 fi
 
+# balena-engine uses iptables-legacy with a FORWARD DROP policy and only adds
+# ACCEPT rules for its own bridges (balena0, supervisor0).  K3s uses
+# iptables-nft (ubuntu:22.04 default), so its flannel/kube-proxy rules never
+# appear in the legacy tables.  Without explicit legacy ACCEPT rules, all pod
+# egress traffic (including DNS from CoreDNS) is silently dropped.
+#
+# We own the EDGE-FORWARD chain entirely -- flush and rebuild on every startup
+# for a guaranteed clean state.  The jump from DOCKER-USER survives
+# balena-engine iptables rebuilds because balena-engine never touches
+# DOCKER-USER contents.
+echo "Setting up iptables-legacy FORWARD rules for k3s networks..."
+iptables-legacy -N EDGE-FORWARD 2>/dev/null || true
+iptables-legacy -F EDGE-FORWARD
+iptables-legacy -A EDGE-FORWARD -s 10.42.0.0/16 -j ACCEPT
+iptables-legacy -A EDGE-FORWARD -d 10.42.0.0/16 -j ACCEPT
+iptables-legacy -A EDGE-FORWARD -s 10.43.0.0/16 -j ACCEPT
+iptables-legacy -A EDGE-FORWARD -d 10.43.0.0/16 -j ACCEPT
+iptables-legacy -C DOCKER-USER -j EDGE-FORWARD 2>/dev/null || \
+    iptables-legacy -I DOCKER-USER -j EDGE-FORWARD
+echo "iptables-legacy rules ready"
+
 # Ensure the root filesystem has shared mount propagation so that k3s pods can use
 # mountPropagation: Bidirectional (needed by the mount-s3 FUSE sidecar).
 # In Balena, the server container's root is private by default.


### PR DESCRIPTION
## Why

Found while debugging a device (`6c2220ebae76dba1db687f2e1df126ff`, `g_harry_tung/x86-edge`) where edge-endpoint initialization was stuck: the `validate-api-token-edge` job couldn't resolve `api.groundlight.ai`, and a debug pod couldn't even ping CoreDNS or the internet from the same node/bridge.

Root cause: balena-engine sets a `FORWARD` `DROP` policy via `iptables-legacy`, with ACCEPT exceptions only for its own bridges (`balena0`, `supervisor0`). k3s/flannel/kube-proxy write their own rules via `iptables-nft` (the `ubuntu:22.04` default), so those rules never land in the legacy tables that balena-engine's `DROP` policy actually enforces. Net effect: all pod-to-pod and pod-to-internet traffic — including DNS lookups from CoreDNS — is silently dropped.

GEP's `server.sh` already carries an equivalent fix for the exact same balenaOS/k3s combination; this ports it over.

## What

Add an `EDGE-FORWARD` chain in `deploy/balena-k3s/server/server.sh`, populated with ACCEPT rules for the k3s pod CIDR (`10.42.0.0/16`) and service CIDR (`10.43.0.0/16`), hooked into `DOCKER-USER` (the chain balena-engine never overwrites). Flushed and rebuilt on every server startup for a guaranteed clean state.

This is a single shared `server.sh`, copied into all three flavors (`Dockerfile`, `Dockerfile.gpu`, `Dockerfile.jetson`), so one change covers CPU, GPU, and Jetson.

## Verification

Applied the equivalent `iptables-legacy` commands live on the affected device (no redeploy) and confirmed:
- Pod → CoreDNS pod-IP ping: 100% loss → 0% loss
- Pod → internet (8.8.8.8) ping: 100% loss → 0% loss
- `nslookup api.groundlight.ai` inside a pod: timeout → resolves correctly
- After clearing the resulting stale Helm release state and reinstalling, `edge-endpoint` deployed cleanly: `6/6` containers running, ECR credential jobs completing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)