### PR TITLE
feat: add cert-rotation sidecar for in-place TLS cert renewal (GL-1699)

### DIFF
--- a/app/bin/generate-tls-cert.sh
+++ b/app/bin/generate-tls-cert.sh
@@ -10,7 +10,7 @@
 # every boot. Regeneration is self-healing: a broken pair is replaced rather than
 # left in place for nginx to choke on later.
 
-set -e
+set -ex
 
 # CERT_DIR is overridable so the generator can be exercised in tests; production
 # deployments mount nginx's cert directory here.

--- a/app/bin/generate-tls-cert.sh
+++ b/app/bin/generate-tls-cert.sh
@@ -10,7 +10,7 @@
 # every boot. Regeneration is self-healing: a broken pair is replaced rather than
 # left in place for nginx to choke on later.
 
-set -ex
+set -e
 
 # CERT_DIR is overridable so the generator can be exercised in tests; production
 # deployments mount nginx's cert directory here.

--- a/app/bin/rotate-tls-cert.sh
+++ b/app/bin/rotate-tls-cert.sh
@@ -1,28 +1,17 @@
 #!/bin/bash
 
-# Runs as a long-lived sidecar and periodically checks whether the pinned TLS
-# cert needs rotation. If the cert is missing, mismatched, or within 30 days of
-# expiry it regenerates the cert and sends SIGHUP to the nginx master process for
-# an in-place reload without restarting the pod.
+# Runs as a long-lived sidecar and periodically ensures the pinned TLS cert is
+# fresh, then signals nginx to reload it in place.
 #
-# Requires shareProcessNamespace: true on the pod spec so this sidecar can signal
-# the nginx master process running in the nginx container.
+# generate-tls-cert.sh is idempotent and skips regeneration when the cert is
+# still valid, so calling it daily is safe. Sending SIGHUP to nginx afterwards
+# is equally harmless when nothing changed: nginx reloads gracefully with no
+# dropped connections.
+#
+# Requires shareProcessNamespace: true on the pod spec so this sidecar can
+# signal the nginx master process running in the nginx container.
 
 CERT_DIR="${CERT_DIR:-/etc/nginx/certs}"
-CERT_FILE="$CERT_DIR/certificate.crt"
-KEY_FILE="$CERT_DIR/private.key"
-
-# Mirrors the cert_is_reusable check in generate-tls-cert.sh.
-cert_is_reusable() {
-    [ -f "$CERT_FILE" ] || return 1
-    [ -f "$KEY_FILE" ] || return 1
-    openssl x509 -checkend 2592000 -noout -in "$CERT_FILE" >/dev/null 2>&1 || return 1
-    local cert_pubkey key_pubkey
-    cert_pubkey=$(openssl x509 -in "$CERT_FILE" -noout -pubkey 2>/dev/null) || return 1
-    key_pubkey=$(openssl pkey -in "$KEY_FILE" -pubout 2>/dev/null) || return 1
-    [ "$cert_pubkey" = "$key_pubkey" ]
-}
-
 CHECK_INTERVAL_SECONDS="${CHECK_INTERVAL_SECONDS:-86400}"
 
 echo "TLS cert rotation watcher started (check interval: ${CHECK_INTERVAL_SECONDS}s)."
@@ -30,19 +19,16 @@ echo "TLS cert rotation watcher started (check interval: ${CHECK_INTERVAL_SECOND
 while true; do
     sleep "$CHECK_INTERVAL_SECONDS"
 
-    if cert_is_reusable; then
-        echo "TLS cert is valid; no rotation needed."
+    if ! CERT_DIR="$CERT_DIR" /bin/bash /groundlight-edge/app/bin/generate-tls-cert.sh; then
+        echo "ERROR: cert generation failed; skipping nginx reload until next check."
         continue
     fi
-
-    echo "TLS cert is missing, mismatched, or near expiry; regenerating..."
-    CERT_DIR="$CERT_DIR" /bin/bash /groundlight-edge/app/bin/generate-tls-cert.sh
 
     nginx_master_pid=$(pgrep -o -f "nginx: master") || true
     if [ -n "$nginx_master_pid" ]; then
         kill -HUP "$nginx_master_pid"
-        echo "TLS cert rotated and nginx reloaded (HUP sent to PID $nginx_master_pid)."
+        echo "nginx reloaded (HUP sent to PID $nginx_master_pid)."
     else
-        echo "WARNING: cert regenerated but nginx master process not found; reload will take effect on next pod restart."
+        echo "WARNING: nginx master process not found; cert will take effect on next pod restart."
     fi
 done

--- a/app/bin/rotate-tls-cert.sh
+++ b/app/bin/rotate-tls-cert.sh
@@ -25,20 +25,28 @@ while true; do
     fi
 
     nginx_master_pid=""
-    # procps is not installed in the production image, so find the nginx master
-    # by scanning /proc directly rather than using pgrep.
-    for pid_dir in /proc/[0-9]*; do
-        pid="${pid_dir##*/}"
-        cmdline_file="$pid_dir/cmdline"
-        [ -r "$cmdline_file" ] || continue
-        cmdline=$(tr '\0' ' ' < "$cmdline_file" 2>/dev/null) || continue
-        case "$cmdline" in
-            *"nginx: master"*"daemon off"*)
-                nginx_master_pid="$pid"
-                break
-                ;;
-        esac
-    done
+    nginx_pid_file="$CERT_DIR/nginx.pid"
+    if [ -f "$nginx_pid_file" ]; then
+        # Helm deployment: the real nginx writes its PID into the shared certs
+        # volume, so we can reload it unambiguously without scanning /proc.
+        nginx_master_pid=$(cat "$nginx_pid_file" 2>/dev/null) || true
+    else
+        # k3s deployment: no separate nginx container, so there is only one
+        # nginx master in the pod. Scan /proc to find it.
+        # procps is not installed in the production image, so we avoid pgrep.
+        for pid_dir in /proc/[0-9]*; do
+            pid="${pid_dir##*/}"
+            cmdline_file="$pid_dir/cmdline"
+            [ -r "$cmdline_file" ] || continue
+            cmdline=$(tr '\0' ' ' < "$cmdline_file" 2>/dev/null) || continue
+            case "$cmdline" in
+                *"nginx: master"*)
+                    nginx_master_pid="$pid"
+                    break
+                    ;;
+            esac
+        done
+    fi
     if [ -n "$nginx_master_pid" ]; then
         kill -HUP "$nginx_master_pid"
         echo "nginx reloaded (HUP sent to PID $nginx_master_pid)."

--- a/app/bin/rotate-tls-cert.sh
+++ b/app/bin/rotate-tls-cert.sh
@@ -33,7 +33,7 @@ while true; do
         [ -r "$cmdline_file" ] || continue
         cmdline=$(tr '\0' ' ' < "$cmdline_file" 2>/dev/null) || continue
         case "$cmdline" in
-            *"nginx: master"*)
+            *"nginx: master"*"daemon off"*)
                 nginx_master_pid="$pid"
                 break
                 ;;

--- a/app/bin/rotate-tls-cert.sh
+++ b/app/bin/rotate-tls-cert.sh
@@ -24,7 +24,21 @@ while true; do
         continue
     fi
 
-    nginx_master_pid=$(pgrep -o -f "nginx: master") || true
+    nginx_master_pid=""
+    # procps is not installed in the production image, so find the nginx master
+    # by scanning /proc directly rather than using pgrep.
+    for pid_dir in /proc/[0-9]*; do
+        pid="${pid_dir##*/}"
+        cmdline_file="$pid_dir/cmdline"
+        [ -r "$cmdline_file" ] || continue
+        cmdline=$(tr '\0' ' ' < "$cmdline_file" 2>/dev/null) || continue
+        case "$cmdline" in
+            *"nginx: master"*)
+                nginx_master_pid="$pid"
+                break
+                ;;
+        esac
+    done
     if [ -n "$nginx_master_pid" ]; then
         kill -HUP "$nginx_master_pid"
         echo "nginx reloaded (HUP sent to PID $nginx_master_pid)."

--- a/app/bin/rotate-tls-cert.sh
+++ b/app/bin/rotate-tls-cert.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Runs as a long-lived sidecar and periodically checks whether the pinned TLS
+# cert needs rotation. If the cert is missing, mismatched, or within 30 days of
+# expiry it regenerates the cert and sends SIGHUP to the nginx master process for
+# an in-place reload without restarting the pod.
+#
+# Requires shareProcessNamespace: true on the pod spec so this sidecar can signal
+# the nginx master process running in the nginx container.
+
+CERT_DIR="${CERT_DIR:-/etc/nginx/certs}"
+CERT_FILE="$CERT_DIR/certificate.crt"
+KEY_FILE="$CERT_DIR/private.key"
+
+# Mirrors the cert_is_reusable check in generate-tls-cert.sh.
+cert_is_reusable() {
+    [ -f "$CERT_FILE" ] || return 1
+    [ -f "$KEY_FILE" ] || return 1
+    openssl x509 -checkend 2592000 -noout -in "$CERT_FILE" >/dev/null 2>&1 || return 1
+    local cert_pubkey key_pubkey
+    cert_pubkey=$(openssl x509 -in "$CERT_FILE" -noout -pubkey 2>/dev/null) || return 1
+    key_pubkey=$(openssl pkey -in "$KEY_FILE" -pubout 2>/dev/null) || return 1
+    [ "$cert_pubkey" = "$key_pubkey" ]
+}
+
+CHECK_INTERVAL_SECONDS="${CHECK_INTERVAL_SECONDS:-86400}"
+
+echo "TLS cert rotation watcher started (check interval: ${CHECK_INTERVAL_SECONDS}s)."
+
+while true; do
+    sleep "$CHECK_INTERVAL_SECONDS"
+
+    if cert_is_reusable; then
+        echo "TLS cert is valid; no rotation needed."
+        continue
+    fi
+
+    echo "TLS cert is missing, mismatched, or near expiry; regenerating..."
+    CERT_DIR="$CERT_DIR" /bin/bash /groundlight-edge/app/bin/generate-tls-cert.sh
+
+    nginx_master_pid=$(pgrep -o -f "nginx: master") || true
+    if [ -n "$nginx_master_pid" ]; then
+        kill -HUP "$nginx_master_pid"
+        echo "TLS cert rotated and nginx reloaded (HUP sent to PID $nginx_master_pid)."
+    else
+        echo "WARNING: cert regenerated but nginx master process not found; reload will take effect on next pod restart."
+    fi
+done

--- a/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
+++ b/deploy/helm/groundlight-edge-endpoint/files/nginx.conf
@@ -2,6 +2,10 @@ events {
     worker_connections 256;
 }
 
+# Write the PID into the shared nginx-certs volume so the cert-rotation
+# sidecar can reload nginx without ambiguity or a procps dependency.
+pid /etc/nginx/certs/nginx.pid;
+
 http {
     # Add "NGINX: " prefix to the log entries to distinguish them from other logs.
     # Follows NGINX's default "combined" log format.

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -59,6 +59,9 @@ spec:
       # This service account is used by the edge logic to access the Kubernetes API
       # from within the pod. See templates/service_account.yaml for more details
       serviceAccountName: edge-endpoint-service-account
+      # Required so the cert-rotation sidecar can send SIGHUP to the nginx master
+      # process to reload the certificate without restarting the pod.
+      shareProcessNamespace: true
       initContainers:
       - name: generate-tls-cert
         image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:{{ include "groundlight-edge-endpoint.edgeEndpointTag" . }}
@@ -170,6 +173,17 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 4  # after 40 seconds of failure, restart the pod
+
+      - name: cert-rotation
+        image: *edgeEndpointImage
+        imagePullPolicy: "{{ include "groundlight-edge-endpoint.edgeEndpointPullPolicy" . }}"
+        resources:
+          requests:
+            memory: "20Mi"
+        command: ["/bin/bash", "/groundlight-edge/app/bin/rotate-tls-cert.sh"]
+        volumeMounts:
+        - name: nginx-certs
+          mountPath: /etc/nginx/certs
 
       - name: edge-endpoint
         image: *edgeEndpointImage

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -177,6 +177,8 @@ spec:
       - name: cert-rotation
         image: *edgeEndpointImage
         imagePullPolicy: "{{ include "groundlight-edge-endpoint.edgeEndpointPullPolicy" . }}"
+        # Allocate some memory for this container. System-critical containers have memory requests so
+        # that they are never evicted, even when the system is under memory pressure.
         resources:
           requests:
             memory: "20Mi"

--- a/deploy/k3s/edge_deployment/edge_deployment.yaml
+++ b/deploy/k3s/edge_deployment/edge_deployment.yaml
@@ -45,6 +45,9 @@ spec:
       # This service account is used by the edge logic to access the Kubernetes API
       # from within the pod. See deploy/k3s/service_account.yaml for more details
       serviceAccountName: edge-endpoint-service-account
+      # Required so the cert-rotation sidecar can send SIGHUP to the nginx master
+      # process to reload the certificate without restarting the pod.
+      shareProcessNamespace: true
       initContainers:
         - name: generate-tls-cert
           image: &edgeEndpointImage 767397850842.dkr.ecr.us-west-2.amazonaws.com/edge-endpoint:${IMAGE_TAG}
@@ -113,6 +116,17 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 4 # after 40 seconds of failure, restart the pod
+
+        - name: cert-rotation
+          image: *edgeEndpointImage
+          imagePullPolicy: Always
+          resources:
+            requests:
+              memory: "20Mi"
+          command: ["/bin/bash", "/groundlight-edge/app/bin/rotate-tls-cert.sh"]
+          volumeMounts:
+            - name: nginx-certs
+              mountPath: /etc/nginx/certs
 
         - name: status-monitor
           image: *edgeEndpointImage


### PR DESCRIPTION
## Add cert-rotation sidecar for in-place TLS cert renewal (GL-1699)

### Summary

Follows up on #448, which pinned the self-signed Lens↔edge TLS cert to device storage so it survives pod restarts. That fixed cert churn on every boot, but the expiry check only ran in the `generate-tls-cert` initContainer at pod startup. A pod running continuously for a year could eventually serve an expired cert.

This PR adds a `cert-rotation` sidecar that checks daily, regenerates the cert if needed, and reloads nginx in place with no pod restart.

### Changes

- **`app/bin/rotate-tls-cert.sh`** (new): daily loop that calls the existing idempotent `generate-tls-cert.sh`, then signals nginx to reload.
- **Helm + legacy k3s manifests**: add `shareProcessNamespace: true` and the `cert-rotation` sidecar.
- **`nginx.conf`**: write `pid /etc/nginx/certs/nginx.pid` so the sidecar can reload the correct nginx in Helm deployments.

### Reload behavior

- **Helm:** real nginx writes its PID to the shared certs volume; sidecar reads it and sends `SIGHUP`.
- **Legacy k3s:** no separate nginx container, so sidecar finds the single nginx master via `/proc` scan (no `procps`/`pgrep` dependency).

The dummy nginx in the Helm `edge-endpoint` container is intentionally not targeted.

### Notes

- At least one device in the field is still on the legacy k3s path; we cannot deprecate it yet.
- Legacy devices won't get cert rotation until they deploy a manifest that includes this sidecar (and #448 cert pinning).
- A daily `SIGHUP` when nothing changed is harmless.

### Jira

https://taserintl.atlassian.net/browse/GL-1699

### Related

- #448 — pinned the cert to device storage (prerequisite)