### PR TITLE
fix: extend self-signed TLS cert lifetime to 10 years (GL-1699)

### DIFF
--- a/app/bin/generate-tls-cert.sh
+++ b/app/bin/generate-tls-cert.sh
@@ -48,7 +48,7 @@ openssl genpkey -algorithm RSA -out private.key -pkeyopt rsa_keygen_bits:2048
 openssl req -new -key private.key -out csr.pem -subj "/C=US/ST=Washington/L=Seattle/O=Groundlight/OU=Engineering/CN=localhost"
 
 # Generate a self-signed certificate
-openssl x509 -req -days 365 -in csr.pem -signkey private.key -out certificate.crt
+openssl x509 -req -days 3650 -in csr.pem -signkey private.key -out certificate.crt
 
 echo "TLS certificate and key generated successfully."
 


### PR DESCRIPTION
The 1-year cert validity meant a long-running pod could eventually serve an
expired cert. This PR extends to 10 years so expiry is not a
practical concern for the device lifetime.

Jira: https://taserintl.atlassian.net/browse/GL-1699
Related: #448 (cert pinning)