### PR TITLE
feat: add independent RUN_OODD flag to decouple OODD from minimal image

### DIFF
--- a/app/core/app_state.py
+++ b/app/core/app_state.py
@@ -23,6 +23,7 @@ MAX_DETECTOR_IDS_CACHE_SIZE = 1000
 STALE_METADATA_THRESHOLD_SEC = 60  # 60 seconds
 
 USE_MINIMAL_IMAGE = os.environ.get("USE_MINIMAL_IMAGE", "false") == "true"
+RUN_OODD = os.environ.get("RUN_OODD", "true") == "true"
 
 
 @lru_cache(maxsize=MAX_SDK_INSTANCES_CACHE_SIZE)
@@ -103,8 +104,9 @@ class AppState:
     def __init__(self):
         # We only launch a separate OODD inference pod if we are not using the minimal image.
         # Pipelines used in the minimal image include OODD inference and confidence adjustment,
-        # so they do not need to be adjusted separately.
-        self.separate_oodd_inference = not USE_MINIMAL_IMAGE
+        # so they do not need to be adjusted separately. OODD can also be disabled entirely
+        # (regardless of the image) via the RUN_OODD flag.
+        self.separate_oodd_inference = (not USE_MINIMAL_IMAGE) and RUN_OODD
         self.edge_inference_manager = EdgeInferenceManager(separate_oodd_inference=self.separate_oodd_inference)
         self.db_manager = DatabaseManager()
         self.is_ready = False

--- a/app/model_updater/update_models.py
+++ b/app/model_updater/update_models.py
@@ -24,6 +24,7 @@ ROLLOUT_READY_TIMEOUT_S = int(os.environ.get("ROLLOUT_READY_TIMEOUT_S", 60 * 30)
 DETECTOR_CONFIG_CHANGE_POLL_INTERVAL_S = 2.0
 
 USE_MINIMAL_IMAGE = os.environ.get("USE_MINIMAL_IMAGE", "false") == "true"
+RUN_OODD = os.environ.get("RUN_OODD", "true") == "true"
 
 
 def sleep_forever(message: str | None = None):
@@ -295,5 +296,5 @@ if __name__ == "__main__":
         edge_inference_manager=edge_inference_manager,
         deployment_manager=deployment_manager,
         db_manager=db_manager,
-        separate_oodd_inference=not USE_MINIMAL_IMAGE,
+        separate_oodd_inference=(not USE_MINIMAL_IMAGE) and RUN_OODD,
     )

--- a/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/templates/edge-deployment.yaml
@@ -195,6 +195,8 @@ spec:
           value: "{{ .Values.upstreamEndpoint }}"
         - name: USE_MINIMAL_IMAGE
           value: "{{ .Values.useMinimalImage }}"
+        - name: RUN_OODD
+          value: "{{ .Values.runOodd }}"
         - name: ENABLE_PROFILING
           value: "{{ .Values.enableProfiling }}"
         volumeMounts:
@@ -310,6 +312,8 @@ spec:
               key: GROUNDLIGHT_API_TOKEN
         - name: USE_MINIMAL_IMAGE
           value: "{{ .Values.useMinimalImage }}"
+        - name: RUN_OODD
+          value: "{{ .Values.runOodd }}"
         - name: ROLLOUT_READY_TIMEOUT_S
           value: "{{ .Values.modelUpdater.rolloutReadyTimeoutSeconds }}"
         volumeMounts:

--- a/deploy/helm/groundlight-edge-endpoint/values.yaml
+++ b/deploy/helm/groundlight-edge-endpoint/values.yaml
@@ -24,6 +24,12 @@ inferenceTag: ""
 # an object detection or counting model. 
 useMinimalImage: false
 
+# When true (default) each detector runs a separate OODD inference pod whose
+# prediction adjusts the primary model's confidence. Set false to disable OODD
+# entirely (no OODD pods launch and no OODD confidence adjustment is applied).
+# Has no effect when useMinimalImage is true, since that image runs OODD in-pipeline.
+runOodd: true
+
 # Enable request-level tracing profiling for the edge endpoint.
 # When enabled, per-request trace data (span timings, annotations) is written to
 # /opt/groundlight/device/edge-profiling/ as JSONL files. Disabled by default.

--- a/test/core/test_app_state.py
+++ b/test/core/test_app_state.py
@@ -1,0 +1,30 @@
+"""Tests for the separate_oodd_inference derivation in AppState."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.core import app_state
+
+
+@pytest.mark.parametrize(
+    ("use_minimal_image", "run_oodd", "expected"),
+    [
+        (False, True, True),
+        (False, False, False),
+        (True, True, False),
+        (True, False, False),
+    ],
+)
+def test_separate_oodd_inference_derivation(monkeypatch, use_minimal_image, run_oodd, expected):
+    monkeypatch.setattr(app_state, "USE_MINIMAL_IMAGE", use_minimal_image)
+    monkeypatch.setattr(app_state, "RUN_OODD", run_oodd)
+
+    with (
+        patch("app.core.app_state.EdgeInferenceManager"),
+        patch("app.core.app_state.DatabaseManager"),
+        patch("app.core.app_state.QueueWriter"),
+    ):
+        state = app_state.AppState()
+
+    assert state.separate_oodd_inference is expected


### PR DESCRIPTION
Previously separate_oodd_inference was derived solely from USE_MINIMAL_IMAGE, so OODD could only be disabled by switching to the minimal image. Add a RUN_OODD flag (helm value runOodd, default true) that ANDs into the derivation, allowing OODD pods/inference to be turned off independently.