### PR TITLE
fix: prevent preview-release-notes job from failing before its empty-tag guard

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -494,8 +494,8 @@ jobs:
             --repository-name edge-endpoint \
             --image-ids imageTag=release \
             --query 'imageDetails[0].imageTags' \
-            --output text)
-          last_release_sha=$(echo "$tags" | tr '\t' '\n' | grep -E '^[0-9a-f]{9}-main$' | head -1 | cut -d- -f1)
+            --output text 2>/dev/null || true)
+          last_release_sha=$(echo "$tags" | tr '\t' '\n' | grep -E '^[0-9a-f]{9}-main$' | head -1 | cut -d- -f1 || true)
           if [[ -z "$last_release_sha" ]]; then
             echo "Could not find a <sha>-main tag on the current 'release' image."
             echo "Tags found: $tags"


### PR DESCRIPTION
## Summary
- The `preview-release-notes` job in `.github/workflows/pipeline.yaml` queries ECR for the image currently tagged `release`, then greps its tags for a `<sha9>-main` pattern to find the last released commit.
- GitHub Actions runs `run:` steps with `bash --noprofile --norc -eo pipefail {0}`, so both `set -e` and `pipefail` are active. If the `release` tag doesn't exist yet (e.g. before the first release, or if it's ever removed), `aws ecr describe-images` throws `ImageNotFoundException` and exits non-zero — the failing command substitution kills the step immediately, before the `if [[ -z "$last_release_sha" ]]` guard can run its friendly "Could not find a tag" message. Same failure mode applies if `grep` matches nothing.
- Adds `|| true` to both the ECR query and the grep pipeline so the guard handles the empty case gracefully instead of the job showing a red X.
- This is purely informational and non-blocking either way (no `needs`, doesn't gate `tag-pre-release`/`tag-release`), but a spurious failure is still noisy/confusing.

This exact issue was flagged during review when this job was ported to GEP's pipeline: axon-groundlight/gep#187 (review comment: https://github.com/axon-groundlight/gep/pull/187#discussion_r3597929679). Applying the same fix here since the bug originated in this repo's job.

## Test plan
- [x] YAML validated locally (parses cleanly)
- [ ] Confirm the job still runs and prints commits when the `release` tag exists
- [ ] Confirm the job prints the friendly "Could not find a tag" message (instead of failing) when the `release` tag is absent